### PR TITLE
묵찌빠 게임 [STEP 2] Jost, Joey

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@
 
 ![RPS_Step1](https://user-images.githubusercontent.com/52592748/120182638-9e598480-c249-11eb-8ee2-f1a4aa30c799.png)
 
+### 플로우차트 Step2
+
+![RPS_Step2](https://images.velog.io/images/jehjong/post/eae16124-3e26-46d4-b711-bbab23517e19/mukjjippa_step2.png)

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -6,6 +6,44 @@
 
 import Foundation
 
+var isGameEnd = false
+let exitNumber = 0
+
+enum MukJJiPPa: Int, CaseIterable {
+    case muk = 1
+    case jji
+    case ppa
+    
+    static func generateRandomHand() -> MukJJiPPa {
+        return MukJJiPPa.allCases.randomElement() ?? .muk
+    }
+    
+    var menuNumber: Int {
+        switch self {
+        case .muk:
+            return 1
+        case .jji:
+            return 2
+        case .ppa:
+            return 3
+        }
+    }
+    
+    func playMukJJiPPa(against opponent: MukJJiPPa) -> GameResult {
+        let numberGap = self.menuNumber - opponent.menuNumber
+        let winNumberGaps = [2, -1]
+        let tieNumberGaps = [0]
+        
+        if winNumberGaps.contains(numberGap) {
+            return .win
+        }
+        if tieNumberGaps.contains(numberGap) {
+            return .tie
+        }
+        return .lose
+    }
+}
+
 enum RockPaperScissors: Int, CaseIterable {
     case scissors = 1
     case rock
@@ -58,12 +96,20 @@ enum GameResult {
     }
 }
 
-func showMenu() {
+func showRockPaperScissorsMenu() {
     print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
+}
+
+func showMukJJiPPaMenu(turnUser: String) {
+    print("[\(turnUser)의 턴] 묵(1), 찌(2), 빠(3)! <종료: 0> : ", terminator: "")
 }
 
 func showWrongInputMessage() {
     print("잘못된 입력입니다. 다시 시도해주세요.")
+}
+
+func showSystemErrorMessage() {
+    print("알수 없는 없는 오류가 발생하였습니다. 다시 시도해주세요.")
 }
 
 func showGameEndMessage() {
@@ -71,7 +117,7 @@ func showGameEndMessage() {
 }
 
 func receiveUserInputNumber() -> Int {
-    showMenu()
+    showRockPaperScissorsMenu()
     let minMenuNumber = 0
     let maxMenuNumber = 3
     guard let userInput = readLine(),
@@ -83,23 +129,78 @@ func receiveUserInputNumber() -> Int {
     return convertedUserInput
 }
 
-func playGame() {
-    let exitNumber = 0
+func playMukJJiPPaGame(turnUser: String, opponent: String) {
+    showMukJJiPPaMenu(turnUser: turnUser)
+    
+    let minMenuNumber = 0
+    let maxMenuNumber = 3
+    guard let userInput = readLine(),
+          let convertedUserInput = Int(userInput),
+          (minMenuNumber...maxMenuNumber).contains(convertedUserInput) else {
+        showWrongInputMessage()
+        if turnUser == "컴퓨터" {
+            playMukJJiPPaGame(turnUser: turnUser, opponent: opponent)
+        } else {
+            playMukJJiPPaGame(turnUser: opponent, opponent: turnUser)
+        }
+        return
+    }
+    
+    if convertedUserInput == 0 {
+        isGameEnd = true
+        showGameEndMessage()
+        return
+    }
+    
+    guard let userHand = MukJJiPPa(rawValue: convertedUserInput) else {
+        showSystemErrorMessage()
+        playMukJJiPPaGame(turnUser: turnUser, opponent: opponent)
+        return
+    }
+    
+    let computerHand = MukJJiPPa.generateRandomHand()
+    
+    let (turnUserHand, opponentHand) = turnUser == "사용자" ? (userHand, computerHand) : (computerHand, userHand)
+    
+    let gameResult: GameResult = turnUserHand.playMukJJiPPa(against: opponentHand)
+    switch gameResult {
+    case .tie:
+        print("\(turnUser)의 승리!")
+    case .lose:
+        print("\(opponent)의 턴 입니다.")
+        playMukJJiPPaGame(turnUser: opponent, opponent: turnUser)
+    case .win:
+        print("\(turnUser)의 턴 입니다.")
+        playMukJJiPPaGame(turnUser: turnUser, opponent: opponent)
+    }
+}
+
+func rockPaperScissorsGame() {
     while true {
         let userInputNumber: Int = receiveUserInputNumber()
         if userInputNumber == exitNumber {
             showGameEndMessage()
-            break
+            return
         }
         if let userHand = RockPaperScissors(rawValue: userInputNumber) {
             let computerHand = RockPaperScissors.generateRandomHand()
             let gameResult: GameResult = userHand.playRockScissorsPaper(against: computerHand)
 
             gameResult.showGameResultMessage()
+            
+            if gameResult == .win {
+                playMukJJiPPaGame(turnUser: "사용자", opponent: "컴퓨터")
+            } else if gameResult == .lose {
+                playMukJJiPPaGame(turnUser: "컴퓨터", opponent: "사용자")
+            }
+            
+            if(isGameEnd == true) {
+                return
+            }
         } else {
             showWrongInputMessage()
         }
     }
 }
 
-playGame()
+rockPaperScissorsGame()

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -10,8 +10,7 @@ typealias Player = (displayName: String, isComputer: Bool)
 
 var isGameEnd = false
 let exitNumber = 0
-let minMenuNumber = 0
-let maxMenuNumber = 3
+let validMenuNumbers = [0, 1, 2, 3]
 
 enum MukJJiPPa: Int, CaseIterable {
     case muk = 1
@@ -23,14 +22,7 @@ enum MukJJiPPa: Int, CaseIterable {
     }
     
     var menuNumber: Int {
-        switch self {
-        case .muk:
-            return 1
-        case .jji:
-            return 2
-        case .ppa:
-            return 3
-        }
+        return self.rawValue
     }
     
     func playMukJJiPPa(against opponent: MukJJiPPa) -> GameResult {
@@ -58,14 +50,7 @@ enum RockPaperScissors: Int, CaseIterable {
     }
     
     var menuNumber: Int {
-        switch self {
-        case .scissors:
-            return 1
-        case .rock:
-            return 2
-        case .paper:
-            return 3
-        }
+        return self.rawValue
     }
     
     func playRockScissorsPaper(against opponent: RockPaperScissors) -> GameResult {
@@ -108,6 +93,14 @@ func showMukJJiPPaMenu(displayName: String) {
     print("[\(displayName)의 턴] 묵(1), 찌(2), 빠(3)! <종료: 0> : ", terminator: "")
 }
 
+func showMukJJiPPaTurn(of displayName: String) {
+    print("\(displayName)의 턴 입니다.")
+}
+
+func showMukJJiPPaVictoryMessage(of displayName: String) {
+    print("\(displayName)의 승리!")
+}
+
 func showWrongInputMessage() {
     print("잘못된 입력입니다. 다시 시도해주세요.")
 }
@@ -125,7 +118,7 @@ func receiveUserInputNumber() -> Int {
 
     guard let userInput = readLine(),
           let convertedUserInput = Int(userInput),
-          (minMenuNumber...maxMenuNumber).contains(convertedUserInput) else {
+          validMenuNumbers.contains(convertedUserInput) else {
         showWrongInputMessage()
         return receiveUserInputNumber()
     }
@@ -137,7 +130,7 @@ func playMukJJiPPaGame(turnUser: Player, opponent: Player) {
     
     guard let userInput = readLine(),
           let convertedUserInput = Int(userInput),
-          (minMenuNumber...maxMenuNumber).contains(convertedUserInput) else {
+          validMenuNumbers.contains(convertedUserInput) else {
         showWrongInputMessage()
         if turnUser.isComputer == true {
             playMukJJiPPaGame(turnUser: turnUser, opponent: opponent)
@@ -165,26 +158,26 @@ func playMukJJiPPaGame(turnUser: Player, opponent: Player) {
     
     switch gameResult {
     case .tie:
-        print("\(turnUser.displayName)의 승리!")
+        showMukJJiPPaVictoryMessage(of: turnUser.displayName)
     case .lose:
-        print("\(opponent.displayName)의 턴 입니다.")
+        showMukJJiPPaTurn(of: opponent.displayName)
         playMukJJiPPaGame(turnUser: opponent, opponent: turnUser)
     case .win:
-        print("\(turnUser.displayName)의 턴 입니다.")
+        showMukJJiPPaTurn(of: turnUser.displayName)
         playMukJJiPPaGame(turnUser: turnUser, opponent: opponent)
     }
 }
 
 func rockPaperScissorsGame() {
     while true {
-        let userInputNumber: Int = receiveUserInputNumber()
+        let userInputNumber = receiveUserInputNumber()
         if userInputNumber == exitNumber {
             showGameEndMessage()
             return
         }
         if let userHand = RockPaperScissors(rawValue: userInputNumber) {
             let computerHand = RockPaperScissors.generateRandomHand()
-            let gameResult: GameResult = userHand.playRockScissorsPaper(against: computerHand)
+            let gameResult = userHand.playRockScissorsPaper(against: computerHand)
 
             gameResult.showGameResultMessage()
             

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -10,6 +10,8 @@ typealias Player = (displayName: String, isComputer: Bool)
 
 var isGameEnd = false
 let exitNumber = 0
+let minMenuNumber = 0
+let maxMenuNumber = 3
 
 enum MukJJiPPa: Int, CaseIterable {
     case muk = 1
@@ -120,8 +122,7 @@ func showGameEndMessage() {
 
 func receiveUserInputNumber() -> Int {
     showRockPaperScissorsMenu()
-    let minMenuNumber = 0
-    let maxMenuNumber = 3
+
     guard let userInput = readLine(),
           let convertedUserInput = Int(userInput),
           (minMenuNumber...maxMenuNumber).contains(convertedUserInput) else {
@@ -134,8 +135,6 @@ func receiveUserInputNumber() -> Int {
 func playMukJJiPPaGame(turnUser: Player, opponent: Player) {
     showMukJJiPPaMenu(displayName: turnUser.displayName)
     
-    let minMenuNumber = 0
-    let maxMenuNumber = 3
     guard let userInput = readLine(),
           let convertedUserInput = Int(userInput),
           (minMenuNumber...maxMenuNumber).contains(convertedUserInput) else {
@@ -161,10 +160,9 @@ func playMukJJiPPaGame(turnUser: Player, opponent: Player) {
     }
     
     let computerHand = MukJJiPPa.generateRandomHand()
-    
     let (turnUserHand, opponentHand) = turnUser.isComputer == true ? (computerHand, userHand) : (userHand, computerHand)
-    
     let gameResult: GameResult = turnUserHand.playMukJJiPPa(against: opponentHand)
+    
     switch gameResult {
     case .tie:
         print("\(turnUser.displayName)의 승리!")

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -6,6 +6,8 @@
 
 import Foundation
 
+typealias Player = (displayName: String, isComputer: Bool)
+
 var isGameEnd = false
 let exitNumber = 0
 
@@ -100,8 +102,8 @@ func showRockPaperScissorsMenu() {
     print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
 }
 
-func showMukJJiPPaMenu(turnUser: String) {
-    print("[\(turnUser)의 턴] 묵(1), 찌(2), 빠(3)! <종료: 0> : ", terminator: "")
+func showMukJJiPPaMenu(displayName: String) {
+    print("[\(displayName)의 턴] 묵(1), 찌(2), 빠(3)! <종료: 0> : ", terminator: "")
 }
 
 func showWrongInputMessage() {
@@ -129,8 +131,8 @@ func receiveUserInputNumber() -> Int {
     return convertedUserInput
 }
 
-func playMukJJiPPaGame(turnUser: String, opponent: String) {
-    showMukJJiPPaMenu(turnUser: turnUser)
+func playMukJJiPPaGame(turnUser: Player, opponent: Player) {
+    showMukJJiPPaMenu(displayName: turnUser.displayName)
     
     let minMenuNumber = 0
     let maxMenuNumber = 3
@@ -138,7 +140,7 @@ func playMukJJiPPaGame(turnUser: String, opponent: String) {
           let convertedUserInput = Int(userInput),
           (minMenuNumber...maxMenuNumber).contains(convertedUserInput) else {
         showWrongInputMessage()
-        if turnUser == "컴퓨터" {
+        if turnUser.isComputer == true {
             playMukJJiPPaGame(turnUser: turnUser, opponent: opponent)
         } else {
             playMukJJiPPaGame(turnUser: opponent, opponent: turnUser)
@@ -160,17 +162,17 @@ func playMukJJiPPaGame(turnUser: String, opponent: String) {
     
     let computerHand = MukJJiPPa.generateRandomHand()
     
-    let (turnUserHand, opponentHand) = turnUser == "사용자" ? (userHand, computerHand) : (computerHand, userHand)
+    let (turnUserHand, opponentHand) = turnUser.isComputer == true ? (computerHand, userHand) : (userHand, computerHand)
     
     let gameResult: GameResult = turnUserHand.playMukJJiPPa(against: opponentHand)
     switch gameResult {
     case .tie:
-        print("\(turnUser)의 승리!")
+        print("\(turnUser.displayName)의 승리!")
     case .lose:
-        print("\(opponent)의 턴 입니다.")
+        print("\(opponent.displayName)의 턴 입니다.")
         playMukJJiPPaGame(turnUser: opponent, opponent: turnUser)
     case .win:
-        print("\(turnUser)의 턴 입니다.")
+        print("\(turnUser.displayName)의 턴 입니다.")
         playMukJJiPPaGame(turnUser: turnUser, opponent: opponent)
     }
 }
@@ -189,9 +191,9 @@ func rockPaperScissorsGame() {
             gameResult.showGameResultMessage()
             
             if gameResult == .win {
-                playMukJJiPPaGame(turnUser: "사용자", opponent: "컴퓨터")
+                playMukJJiPPaGame(turnUser: (displayName: "사용자", isComputer: false) , opponent: (displayName: "컴퓨터", isComputer: true))
             } else if gameResult == .lose {
-                playMukJJiPPaGame(turnUser: "컴퓨터", opponent: "사용자")
+                playMukJJiPPaGame(turnUser: (displayName: "컴퓨터", isComputer: true), opponent: (displayName: "사용자", isComputer: false))
             }
             
             if(isGameEnd == true) {


### PR DESCRIPTION
@leejun6694 
쿠마의 피드백을 반영해 Step1을 수정하였습니다 🥳

### 궁금한 점
- 쿠마의 피드백을 받아 `RockPaperScissors`와 `MukJJiPPa` 열거형의 연산프로퍼티에 switch를 생략하고 아래와 같이 구현해봤습니다. 혹시 의도와 맞게 작성한 것인지, 아니면 참고할만한 레퍼런스가 있는지 조언 부탁드립니다 🙏
```swift
enum MukJJiPPa: Int, CaseIterable {
    case muk = 1
    case jji
    case ppa
    
    var menuNumber: Int {
        return self.rawValue
    }
}
```

### Step2 구현 사항

- `142 ~ 146` - 컴퓨터 턴에서 사용자가 잘못된 입력값을 입력했을 때에도 턴이 바뀌는 부분을 추가했습니다.
- 전역 변수를 분리한 것은 추후에 클래스로 변경하게 될 경우 프로퍼티로 변경하면 되는 변수들이라는 점을 고려한 것입니다.
- `가위 (1), 바위 (2), 보(3)` 인 반면 묵찌빠는 `묵(1), 찌(2), 빠(3)` 해당하는 값이 달라 새로운 열거형 `MukJJiPPa`를 선언했습니다.
- 묵찌빠를 실행하는 함수 `playMukJJiPPaGame()` 는 `turnUser` 의 턴으로 `opponent` 와 묵찌빠 게임을 한다고 정의해 재귀적으로 구현했습니다.
  - 사용자 턴에서 사용자가 입력을 잘못했을 때 턴을 교대하여 다시 `playMukJJiPPaGame()`으로 묵찌빠 게임을 실행하도록 했습니다.
  - 반대로 컴퓨터 턴에서 사용자가 입력을 잘못하였을 경우 턴 교대없이 `playMukJJiPPaGame()`으로 묵찌빠 게임을 실행하도록 했습니다.
  - 예외처리를 다 했지만 옵셔널 바인딩에서 혹여나 생길 수 있는 예외 상황에는 턴 교대 없이 `playMukJJiPPaGame()`으로 묵찌빠 게임을 실행하도록 했습니다. 
- `typealias` 를 선언하고 `isComputer` 라는 플래그를 통해 하드코딩 문제를 해결했습니다. (깃헙 커밋 아이디: `eb8f5e0`)