### PR TITLE
묵찌빠 게임 [Step 2] 차차, 제이티

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,24 @@
 - body는 72자마다 줄 바꾸기
 - body는 어떻게 보다 무엇을, 왜 에 맞춰 작성하기
 
+## STEP 1
 
-## 고민되었던 점 및 해결방법
+### 고민되었던 점 및 해결방법
 
-### - Sign vs SignFactory
+#### - Sign vs SignFactory
 
 Sign 타입 내에서 기존에 Sign을 생성하는 타입 메서드를 구현하였으나, SignFactory라는 Sign을 생성, 관리하는 새로운 타입을 만들어야하나 고민이 있었습니다. 
 
 > 해결 방법 : Sign내의 타입 메서드를 SignFactory에 옮겨 구현하였습니다. 
-> 
+>
 > Sign 타입에는 중요한 특성만을 가지도록 만들어주기 위해 추가적인 기능은 붙이지 않았고, Sign 타입을 활용하여 생성, 관리하는 메서드는 SignFactory라는 타입을 새로 만들어 해당 타입 내에 구현해주었습니다. 
 
-### - Switch vs If
+#### - Switch vs If
 
 switch와 If 사이에서 가독성의 관점에서 어느 것이 더 좋은 방법인지 고민해봤습니다. 
 
 - Switch
+
 ```swift
 func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     switch computerSign {
@@ -62,6 +64,7 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
 
 
 - If
+
 ```swift
 func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     if userSign == computerSign.counter {
@@ -75,15 +78,16 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
 ```
 
 > 해결 방법 : case가 명확한 상황에서는 switch, 추가적인 판단이 필요한 경우 if를 선택했습니다.
-> 
+>
 > 코드를 간결하게 만드는 것과 의미를 명확하게 하고자 하는 방법 사이에서 적절한 방식을 선택했습니다.
 
 
-### - Recursive vs Iterative
+#### - Recursive vs Iterative
 
 게임을 실행하기 위한 playGame을 구현할 때 recursively하게 구현할 지, iteratively하게 구현할 지에 대해 고민했습니다. 
 
 - Recursive
+
 ```swift
 func playGame() {
     printMenu()
@@ -108,6 +112,7 @@ func playGame() {
 ```
 
 - Iterative
+
 ```swift
 func playGame() {
     var gameResult: GameResult? = nil
@@ -136,10 +141,10 @@ func playGame() {
 ```
 
 > 해결 방법 : 재귀문으로 구현했습니다.
-> 
+>
 > 더 간결하고 문제의 제약 사항을 지키기에 적합한 방법이라고 생각되었습니다. 하지만 반복문에 비해 덜 직관적이라는 부분은 있는 것 같습니다. 
 
-### - Enumerations 활용 
+#### - Enumerations 활용 
 
 - `Validity`
   : invalid한 경우에는 유효하지 않다는 결과만 출력하도록 하고, valid한 경우 유효하다는 정보와 유효한 입력을 함께 반환하도록 했습니다. 
@@ -150,57 +155,68 @@ func playGame() {
   - `Self` : 타입 이름을 반복적으로 사용하지 않게 도와주는 역할을 합니다. 타입 프로퍼티/메서드를 호출할 때 앞에 `Self`를 붙여 사용합니다.
   - `self` : 모든 인스턴스들이 암시적으로 생성하는 프로퍼티를 의미하며, 인스턴스 프로퍼티/메서드를 호출할 때 `self`를 붙여 사용합니다.
 
-### - 네이밍 
+#### - 네이밍 
 
 함수, 타입, 매개변수의 이름에 역할이 명확하게 표현되도록 고민하여 네이밍했습니다.
 
-### - Optional
+#### - Optional
 
 - `generateRandomElement` 메서드 내에서 사용되는 `randomElement` 메서드는 대상 배열이 비어있을 경우 nil을 반환할 수 있습니다. 하지만 `Sign.allCases`에서는 빈 배열이 반환되는 경우가 없으나, 혹시나 nil이 반환되는 faltalError를 사용하여 고의로 오류를 발생시켜 논리적 오류를 재확인하도록 하였습니다.
-- optional을 처리해줄 때, 빠른 종료의 장점을 갖는 `guard let` 구문을 사용했었습니다.  
+- optional을 처리해줄 때, 빠른 종료의 장점을 갖는 `guard let` 구문을 사용했었습니다.
 
-## 미해결 
+## STEP 2
 
-### - fatalError
+### 고민되었던 점 및 해결방법
 
-```swift
-init(userInput: Int) {
-    switch userInput {
-    case 1:
-        self = .scissors
-    case 2:
-        self = .rock
-    case 3:
-        self = .paper
-    default:
-        fatalError("\(Self.self)의 \(#function)에서 초기화에 실패했습니다")
-    }
-}
-```
+#### - randomElement
 
+프로그램을 실행하였을 때 무승부가 연속으로 약 4~5회 나오는 상황을 여러 번 마주쳤습니다. 매우 낮은 확률의 상황이 자주 발생하여 작성한 코드에서 랜덤값을 불러오는 부분에 구현이 잘못된 게 없는지 고민했습니다. randomElement 메소드가 항상 랜덤한 값을 반환하는지 확인이 필요했습니다.
 
-### - `case .valid(let userInput):` vs `case .valid(userInput):`
+> 해결 방법 : Github에 올라온 Swift 코드를 확인해 보았습니다.
 
 ```swift
-func playGame() {
-    printMenu()
-    let userInput = getUserInput()
-    let validationResult = isValid(userInput: userInput)
-    
-    switch validationResult {
-    case .invalid:
-        printInputError()
-        playGame()
-    case .valid(0):
-        printGameOver()
-    case .valid(let userInput):
-        let (userSign, computerSign) = generatePlayersSign(userInput: userInput)
-        let gameResult = checkWinner(userSign: userSign, computerSign: computerSign)
-        printGameResult(gameResult: gameResult)
-        (gameResult == .draw) ? playGame() : printGameOver()
-    }
-}
+public func randomElement<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> Element? {
+    guard !isEmpty else { return nil }
+    let random = Int.random(in: 0 ..< count, using: &generator)
+    let idx = index(startIndex, offsetBy: random)
+    return self[idx]
+  }
 ```
 
+#### - Protocol
 
+- Equatable
 
+  enum Game의 값을 비교할 때 에러가 발생했습니다. 에러 메세지를 읽어 보니 Equatable을 채택해야 한다고 하여 이유가 궁금해졌습니다.
+
+  > 해결 방법 : Apple의 공식 문서를 확인해보았습니다.
+  >
+  > 그 이유는 다음 문구에서 찾아볼 수 있었습니다. "For an enum, all its associated values must conform to Equatable. (An enum without associated values has Equatable conformance even without the declaration.)"
+
+- CustomStringConvertible
+
+  기존에 하드코딩한 방식으로 문구를 출력하는 코드가 있었습니다. 어떻게 하면 기존 코드를 가독성 좋게 하면서 하드코딩을 하지 않게 할 수 있는지 고민해보았습니다.
+
+  > 해결 방법:  재사용성을 높이기 위해 Player 타입을 추가해주었고, 추가 과정에서 RawValue를 사용하지 않고 문구를 출력하기 위해 Player 타입에 CustomStringConvertible을 채택하였습니다.
+
+#### - 함수 재사용 및 기존 코드 확장성 증대
+
+- 새로운 타입 추가
+
+  - Player
+
+    현재 플레이어 정보가 출력되는 부분의 재사용성을 높이기 위해 Player 타입을 사용하였습니다.
+
+  - Game
+
+    기존 함수의 재사용을 위해서 Game 타입을 매개변수로 사용하여 가위바위보/묵찌빠인 경우에 따라 다르게 실행 되도록 해주었습니다. generatePlayersSign과 printGameMenu 함수에서 해당 타입을 받도록 했습니다.
+
+- GameResult의 값 수정
+
+  기존의 draw 값은 가위바위보에서 서로 낸 게 같은 것을 의미하였습니다. 하지만 묵찌빠에서 draw 값을 그대로 쓸 경우 서로 같은 걸 냈더라도 비겼다는 의미로 읽혀서 네이밍을 바꾸어주어야겠다는 고민을 했습니다.
+
+  > 해결 방법:  GameResult의 값 draw를 값 same으로 수정하였습니다.
+  >
+  > 가위바위보에서는 서로 낸 게 '같은' 게 비긴 거고 묵찌빠에서는 서로 낸 게 '같은' 게 이긴 것이기 때문에 draw를 same으로 바꾸어 재사용성을 높였습니다.

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -65,7 +65,7 @@ enum SignFactory {
 enum GameResult {
     case userWin
     case computerWin
-    case draw
+    case same
 }
 
 enum Game: Equatable {
@@ -130,7 +130,7 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     if userSign == computerSign.counter {
         return .userWin
     } else if userSign == computerSign {
-        return .draw
+        return .same
     } else {
         return .computerWin
     }
@@ -160,7 +160,7 @@ func printGameResult(gameResult: GameResult?) {
         print("이겼습니다!")
     case .computerWin:
         print("졌습니다!")
-    case .draw:
+    case .same:
         print("비겼습니다!")
     default:
         print("컴퓨터가 판단할 수 없습니다")
@@ -188,7 +188,29 @@ func playRockPaperScissorsGame() -> GameResult? {
         let (userSign, computerSign) = generatePlayersSign(userInput: userInput, gameType: .rockPaperScissors)
         gameResult = checkWinner(userSign: userSign, computerSign: computerSign)
         printGameResult(gameResult: gameResult)
-        gameResult = (gameResult == .draw) ? playRockPaperScissorsGame() : (gameResult)
+        gameResult = (gameResult == .same) ? playRockPaperScissorsGame() : (gameResult)
     }
     return gameResult
+}
+
+func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
+    printGameMenu(gameType: .mukJjiPpa(prevResult: prevResult))
+    let userInput = getUserInput()
+    let validationResult = isValid(userInput: userInput)
+    
+    switch validationResult {
+    case .invalid:
+        printInputError()
+        let gameResult = playMukJjiPpaGame(prevResult: prevResult)
+        return gameResult
+    case .valid(0):
+        printGameOver()
+        return nil
+    case .valid(let userInput):
+        let (userSign, computerSign) = generatePlayersSign(userInput: userInput, gameType: .mukJjiPpa(prevResult: prevResult))
+        let currentGameResult = checkWinner(userSign: userSign, computerSign: computerSign)
+        currentGameResult != .same ? print("\(checkTurn(prevResult: currentGameResult))턴 입니다") : ()
+        let finalGameResult = (currentGameResult == .same) ? (prevResult) : playMukJjiPpaGame(prevResult: currentGameResult)
+        return finalGameResult
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -68,6 +68,11 @@ enum GameResult {
     case draw
 }
 
+enum Game {
+    case rockPaperScissors
+    case mukJjiPpa(prevResult: GameResult)
+}
+
 enum Validity {
     case invalid
     case valid(userInput: Int)
@@ -124,8 +129,14 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     }
 }
 
-func printMenu() {
-    print("가위(1), 바위(2), 보(3)! <종료 : 0> : ", terminator: "")
+func printGameMenu(gameType: Game) {
+    switch gameType {
+    case .rockPaperScissors:
+        print("가위(1), 바위(2), 보(3)! <종료 : 0> : ", terminator: "")
+    case .mukJjiPpa(let prevResult):
+        let prevWinner = (prevResult == .userWin) ? "사용자" : "컴퓨터"
+        print("[\(prevWinner) 턴] 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
+    }
 }
 
 func printInputError() {
@@ -150,7 +161,7 @@ func printGameOver() {
 }
 
 func playRockPaperScissorsGame() -> GameResult? {
-    printMenu()
+    printGameMenu(gameType: .rockPaperScissors)
     let userInput = getUserInput()
     let validationResult = isValid(userInput: userInput)
     var gameResult: GameResult?
@@ -170,5 +181,3 @@ func playRockPaperScissorsGame() -> GameResult? {
     }
     return gameResult
 }
-
-

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -68,7 +68,7 @@ enum GameResult {
     case draw
 }
 
-enum Game {
+enum Game: Equatable {
     case rockPaperScissors
     case mukJjiPpa(prevResult: GameResult)
 }
@@ -112,8 +112,15 @@ func isValid(userInput: Int?) -> Validity {
     return .valid(userInput: userInput)
 }
 
-func generatePlayersSign(userInput: Int) -> (userSign: Sign, computerSign: Sign) {
-    let userSign = Sign(rockPaperScissorsUserInput: userInput)
+func generatePlayersSign(userInput: Int, gameType: Game) -> (userSign: Sign, computerSign: Sign) {
+    let userSign: Sign
+
+    if gameType == .rockPaperScissors {
+        userSign = Sign(rockPaperScissorsUserInput: userInput)
+    } else {
+        userSign = Sign(mukJjiPpaUserInput: userInput)
+    }
+    
     let computerSign = SignFactory.generateRandomElement()
     
     return (userSign, computerSign)
@@ -178,7 +185,7 @@ func playRockPaperScissorsGame() -> GameResult? {
         printGameOver()
         return nil
     case .valid(let userInput):
-        let (userSign, computerSign) = generatePlayersSign(userInput: userInput)
+        let (userSign, computerSign) = generatePlayersSign(userInput: userInput, gameType: .rockPaperScissors)
         gameResult = checkWinner(userSign: userSign, computerSign: computerSign)
         printGameResult(gameResult: gameResult)
         gameResult = (gameResult == .draw) ? playRockPaperScissorsGame() : (gameResult)

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -129,13 +129,17 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     }
 }
 
+func checkTurn(prevResult: GameResult) -> String {
+    return (prevResult == .userWin) ? "사용자" : "컴퓨터"
+}
+
 func printGameMenu(gameType: Game) {
     switch gameType {
     case .rockPaperScissors:
         print("가위(1), 바위(2), 보(3)! <종료 : 0> : ", terminator: "")
     case .mukJjiPpa(let prevResult):
-        let prevWinner = (prevResult == .userWin) ? "사용자" : "컴퓨터"
-        print("[\(prevWinner) 턴] 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
+        let player = checkTurn(prevResult: prevResult)
+        print("[\(player) 턴] 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
     }
 }
 

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -114,10 +114,14 @@ enum Menu {
     }
 }
 
-func getUserInput() -> Int? {
+func receiveUserInput() -> Int? {
     guard let userInput = readLine()?.replacingOccurrences(of: " ", with: "") else {
         return nil
     }
+    guard userInput.count == 1 else {
+        return nil
+    }
+    
     return Int(userInput)
 }
 
@@ -226,7 +230,7 @@ func printFinalWinner(finalResult: GameResult) {
 
 func playRockPaperScissorsGame() -> GameResult? {
     printGameMenu(gameType: .rockPaperScissors)
-    let userInput = getUserInput()
+    let userInput = receiveUserInput()
     let validationResult = isValid(userInput: userInput)
     var gameResult: GameResult?
     
@@ -248,7 +252,7 @@ func playRockPaperScissorsGame() -> GameResult? {
 
 func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
     printGameMenu(gameType: .mukJjiPpa(prevResult: prevResult))
-    let userInput = getUserInput()
+    let userInput = receiveUserInput()
     let validationResult = isValid(userInput: userInput)
     
     switch validationResult {

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -92,11 +92,26 @@ enum Validity {
     case valid(userInput: Int)
 }
 
-enum Menu: Int {
+enum Menu {
     case zero
     case one
     case two
     case three
+    
+    init?(input: Int) {
+        switch input {
+        case 0:
+            self = .zero
+        case 1:
+            self = .one
+        case 2:
+            self = .two
+        case 3:
+            self = .three
+        default:
+            return nil
+        }
+    }
 }
 
 func getUserInput() -> Int? {
@@ -107,8 +122,8 @@ func getUserInput() -> Int? {
 }
 
 func isWithinRange(input: Int) -> Bool {
-    switch input {
-    case Menu.zero.rawValue, Menu.one.rawValue, Menu.two.rawValue, Menu.three.rawValue:
+    switch Menu(input: input) {
+    case .zero, .one, .two, .three:
         return true
     default:
         return false

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -201,6 +201,14 @@ func printGameOver() {
     print("게임 종료")
 }
 
+func printFinalWinner(finalResult: GameResult) {
+    guard let finalWinner = checkWinner(prevResult: finalResult) else {
+        return
+    }
+    
+    print("\(finalWinner)의 승리!")
+}
+
 func playRockPaperScissorsGame() -> GameResult? {
     printGameMenu(gameType: .rockPaperScissors)
     let userInput = getUserInput()
@@ -243,14 +251,6 @@ func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
         let finalGameResult = (currentGameResult == .same) ? (prevResult) : playMukJjiPpaGame(prevResult: currentGameResult)
         return finalGameResult
     }
-}
-
-func printFinalWinner(finalResult: GameResult) {
-    guard let finalWinner = checkWinner(prevResult: finalResult) else {
-        return
-    }
-    
-    print("\(finalWinner)의 승리!")
 }
 
 func playGame() {

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -140,7 +140,7 @@ func generatePlayersSign(userInput: Int, gameType: Game) -> (userSign: Sign, com
     return (userSign, computerSign)
 }
 
-func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
+func checkGameResult(userSign: Sign, computerSign: Sign) -> GameResult {
     if userSign == computerSign.counter {
         return .userWin
     } else if userSign == computerSign {
@@ -150,7 +150,7 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     }
 }
 
-func checkTurn(prevResult: GameResult) -> Player? {
+func checkWinner(prevResult: GameResult) -> Player? {
     if prevResult == .userWin {
         return Player.user
     } else if prevResult == .computerWin {
@@ -165,7 +165,7 @@ func printGameMenu(gameType: Game) {
     case .rockPaperScissors:
         print("가위(1), 바위(2), 보(3)! <종료 : 0> : ", terminator: "")
     case .mukJjiPpa(let prevResult):
-        guard let player = checkTurn(prevResult: prevResult) else {
+        guard let player = checkWinner(prevResult: prevResult) else {
             return
         }
         print("[\(player) 턴] 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
@@ -190,7 +190,7 @@ func printGameResult(gameResult: GameResult?) {
 }
 
 func printMukJjiPpaGameResult(gameResult: GameResult) {
-    guard let currentTurn = checkTurn(prevResult: gameResult) else {
+    guard let currentTurn = checkWinner(prevResult: gameResult) else {
         return
     }
     
@@ -216,7 +216,7 @@ func playRockPaperScissorsGame() -> GameResult? {
         return nil
     case .valid(let userInput):
         let (userSign, computerSign) = generatePlayersSign(userInput: userInput, gameType: .rockPaperScissors)
-        gameResult = checkWinner(userSign: userSign, computerSign: computerSign)
+        gameResult = checkGameResult(userSign: userSign, computerSign: computerSign)
         printGameResult(gameResult: gameResult)
         gameResult = (gameResult == .same) ? playRockPaperScissorsGame() : (gameResult)
     }
@@ -238,7 +238,7 @@ func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
         return nil
     case .valid(let userInput):
         let (userSign, computerSign) = generatePlayersSign(userInput: userInput, gameType: .mukJjiPpa(prevResult: prevResult))
-        let currentGameResult = checkWinner(userSign: userSign, computerSign: computerSign)
+        let currentGameResult = checkGameResult(userSign: userSign, computerSign: computerSign)
         printMukJjiPpaGameResult(gameResult: currentGameResult)
         let finalGameResult = (currentGameResult == .same) ? (prevResult) : playMukJjiPpaGame(prevResult: currentGameResult)
         return finalGameResult
@@ -246,7 +246,7 @@ func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
 }
 
 func printFinalWinner(finalResult: GameResult) {
-    guard let finalWinner = checkTurn(prevResult: finalResult) else {
+    guard let finalWinner = checkWinner(prevResult: finalResult) else {
         return
     }
     

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -11,12 +11,25 @@ enum Sign: CaseIterable {
     case rock
     case paper
     
-    init(userInput: Int) {
-        switch userInput {
+    init(rockPaperScissorsUserInput: Int) {
+        switch rockPaperScissorsUserInput {
         case 1:
             self = .scissors
         case 2:
             self = .rock
+        case 3:
+            self = .paper
+        default:
+            fatalError("\(Self.self)의 \(#function)에서 초기화에 실패했습니다")
+        }
+    }
+    
+    init(mukJjiPpaUserInput: Int) {
+        switch mukJjiPpaUserInput {
+        case 1:
+            self = .rock
+        case 2:
+            self = .scissors
         case 3:
             self = .paper
         default:
@@ -95,7 +108,7 @@ func isValid(userInput: Int?) -> Validity {
 }
 
 func generatePlayersSign(userInput: Int) -> (userSign: Sign, computerSign: Sign) {
-    let userSign = Sign(userInput: userInput)
+    let userSign = Sign(rockPaperScissorsUserInput: userInput)
     let computerSign = SignFactory.generateRandomElement()
     
     return (userSign, computerSign)

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -1,8 +1,8 @@
 //
 //  RockPaperScissors - main.swift
-//  Created by yagom. 
+//  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
-// 
+//
 
 import Foundation
 
@@ -66,6 +66,20 @@ enum GameResult {
     case userWin
     case computerWin
     case same
+}
+
+enum Player: CustomStringConvertible {
+    case user
+    case computer
+    
+    var description: String {
+        switch self {
+        case .user:
+            return "사용자"
+        case .computer:
+            return "컴퓨터"
+        }
+    }
 }
 
 enum Game: Equatable {
@@ -136,11 +150,11 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     }
 }
 
-func checkTurn(prevResult: GameResult) -> String? {
+func checkTurn(prevResult: GameResult) -> Player? {
     if prevResult == .userWin {
-        return "사용자"
+        return Player.user
     } else if prevResult == .computerWin {
-        return "컴퓨터"
+        return Player.computer
     } else {
         return nil
     }
@@ -231,6 +245,14 @@ func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
     }
 }
 
+func printFinalWinner(finalResult: GameResult) {
+    guard let finalWinner = checkTurn(prevResult: finalResult) else {
+        return
+    }
+    
+    print("\(finalWinner)의 승리!")
+}
+
 func playGame() {
     guard let rockPaperScissorsResult = playRockPaperScissorsGame() else {
         return
@@ -238,13 +260,8 @@ func playGame() {
     guard let finalResult = playMukJjiPpaGame(prevResult: rockPaperScissorsResult) else {
         return
     }
-    if finalResult == .userWin {
-        print("사용자의 승리!")
-    } else if finalResult == .computerWin {
-        print("컴퓨터의 승리!")
-    } else {
-        print("잘못된 게임 결과입니다")
-    }
+    
+    printFinalWinner(finalResult: finalResult)
 }
 
 playGame()

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -214,3 +214,21 @@ func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
         return finalGameResult
     }
 }
+
+func playGame() {
+    guard let rockPaperScissorsResult = playRockPaperScissorsGame() else {
+        return
+    }
+    guard let finalResult = playMukJjiPpaGame(prevResult: rockPaperScissorsResult) else {
+        return
+    }
+    if finalResult == .userWin {
+        print("사용자의 승리!")
+    } else if finalResult == .computerWin {
+        print("컴퓨터의 승리!")
+    } else {
+        print("잘못된 게임 결과입니다")
+    }
+}
+
+playGame()

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -167,6 +167,21 @@ func printGameResult(gameResult: GameResult?) {
     }
 }
 
+func printMukJjiPpaGameResult(gameResult: GameResult) {
+    let winner: String
+    
+    switch gameResult {
+    case .userWin:
+        winner = checkTurn(prevResult: .userWin)
+    case .computerWin:
+        winner = checkTurn(prevResult: .computerWin)
+    case .same:
+        return
+    }
+    
+    print("\(winner)의 턴입니다.")
+}
+
 func printGameOver() {
     print("게임 종료")
 }
@@ -209,7 +224,7 @@ func playMukJjiPpaGame(prevResult: GameResult) -> GameResult? {
     case .valid(let userInput):
         let (userSign, computerSign) = generatePlayersSign(userInput: userInput, gameType: .mukJjiPpa(prevResult: prevResult))
         let currentGameResult = checkWinner(userSign: userSign, computerSign: computerSign)
-        currentGameResult != .same ? print("\(checkTurn(prevResult: currentGameResult))턴 입니다") : ()
+        printMukJjiPpaGameResult(gameResult: currentGameResult)
         let finalGameResult = (currentGameResult == .same) ? (prevResult) : playMukJjiPpaGame(prevResult: currentGameResult)
         return finalGameResult
     }

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -136,8 +136,14 @@ func checkWinner(userSign: Sign, computerSign: Sign) -> GameResult {
     }
 }
 
-func checkTurn(prevResult: GameResult) -> String {
-    return (prevResult == .userWin) ? "사용자" : "컴퓨터"
+func checkTurn(prevResult: GameResult) -> String? {
+    if prevResult == .userWin {
+        return "사용자"
+    } else if prevResult == .computerWin {
+        return "컴퓨터"
+    } else {
+        return nil
+    }
 }
 
 func printGameMenu(gameType: Game) {
@@ -145,7 +151,9 @@ func printGameMenu(gameType: Game) {
     case .rockPaperScissors:
         print("가위(1), 바위(2), 보(3)! <종료 : 0> : ", terminator: "")
     case .mukJjiPpa(let prevResult):
-        let player = checkTurn(prevResult: prevResult)
+        guard let player = checkTurn(prevResult: prevResult) else {
+            return
+        }
         print("[\(player) 턴] 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
     }
 }
@@ -168,18 +176,11 @@ func printGameResult(gameResult: GameResult?) {
 }
 
 func printMukJjiPpaGameResult(gameResult: GameResult) {
-    let winner: String
-    
-    switch gameResult {
-    case .userWin:
-        winner = checkTurn(prevResult: .userWin)
-    case .computerWin:
-        winner = checkTurn(prevResult: .computerWin)
-    case .same:
+    guard let currentTurn = checkTurn(prevResult: gameResult) else {
         return
     }
     
-    print("\(winner)의 턴입니다.")
+    print("\(currentTurn)의 턴입니다.")
 }
 
 func printGameOver() {

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -119,7 +119,7 @@ func printInputError() {
     print("잘못된 입력입니다. 다시 시도해주세요.")
 }
 
-func printGameResult(gameResult: GameResult) {
+func printGameResult(gameResult: GameResult?) {
     switch gameResult {
     case .userWin:
         print("이겼습니다!")
@@ -127,6 +127,8 @@ func printGameResult(gameResult: GameResult) {
         print("졌습니다!")
     case .draw:
         print("비겼습니다!")
+    default:
+        print("컴퓨터가 판단할 수 없습니다")
     }
 }
 
@@ -134,25 +136,26 @@ func printGameOver() {
     print("게임 종료")
 }
 
-func playGame() {
+func playRockPaperScissorsGame() -> GameResult? {
     printMenu()
     let userInput = getUserInput()
     let validationResult = isValid(userInput: userInput)
+    var gameResult: GameResult?
     
     switch validationResult {
     case .invalid:
         printInputError()
-        playGame()
+        gameResult = playRockPaperScissorsGame()
     case .valid(0):
         printGameOver()
+        return nil
     case .valid(let userInput):
         let (userSign, computerSign) = generatePlayersSign(userInput: userInput)
-        let gameResult = checkWinner(userSign: userSign, computerSign: computerSign)
+        gameResult = checkWinner(userSign: userSign, computerSign: computerSign)
         printGameResult(gameResult: gameResult)
-        (gameResult == .draw) ? playGame() : printGameOver()
+        gameResult = (gameResult == .draw) ? playRockPaperScissorsGame() : (gameResult)
     }
+    return gameResult
 }
-
-playGame()
 
 


### PR DESCRIPTION
안녕하세요 타코캣! @Ldoy
3모둠 차차와 제이티입니다.
step 2까지 완료하여 PR 보냅니다!
이전에 step 1에서 주신 피드백 내용도 반영하였습니다.
감사합니다. 잘 부탁드립니다!

## 고민되었던 점 및 해결방법
### - randomElement

프로그램을 실행하였을 때 무승부가 연속으로 약 4~5회 나오는 상황을 여러 번 마주쳤습니다. 매우 낮은 확률의 상황이 자주 발생하여 작성한 코드에서 랜덤값을 불러오는 부분에 구현이 잘못된 게 없는지 고민했습니다. randomElement 메소드가 항상 랜덤한 값을 반환하는지 확인이 필요했습니다.

> 해결 방법 : Github에 올라온 Swift 코드를 확인해 보았습니다.

```swift
public func randomElement<T: RandomNumberGenerator>(
    using generator: inout T
  ) -> Element? {
    guard !isEmpty else { return nil }
    let random = Int.random(in: 0 ..< count, using: &generator)
    let idx = index(startIndex, offsetBy: random)
    return self[idx]
  }
```

### - Protocol

- Equatable

  enum Game의 값을 비교할 때 에러가 발생했습니다. 에러 메세지를 읽어 보니 Equatable을 채택해야 한다고 하여 이유가 궁금해졌습니다.

  > 해결 방법 : Apple의 공식 문서를 확인해보았습니다.
  >
  > 그 이유는 다음 문구에서 찾아볼 수 있었습니다. "For an enum, all its associated values must conform to Equatable. (An enum without associated values has Equatable conformance even without the declaration.)"

- CustomStringConvertible

  기존에 하드코딩한 방식으로 문구를 출력하는 코드가 있었습니다. 어떻게 하면 기존 코드를 가독성 좋게 하면서 하드코딩을 하지 않게 할 수 있는지 고민해보았습니다.

  > 해결 방법:  재사용성을 높이기 위해 Player 타입을 추가해주었고, 추가 과정에서 RawValue를 사용하지 않고 문구를 출력하기 위해 Player 타입에 CustomStringConvertible을 채택하였습니다.

### - 함수 재사용 및 기존 코드 확장성 증대

- 새로운 타입 추가

  - Player

    현재 플레이어 정보가 출력되는 부분의 재사용성을 높이기 위해 Player 타입을 사용하였습니다.

  - Game

    기존 함수의 재사용을 위해서 Game 타입을 매개변수로 사용하여 가위바위보/묵찌빠인 경우에 따라 다르게 실행 되도록 해주었습니다. generatePlayersSign과 printGameMenu 함수에서 해당 타입을 받도록 했습니다.

- GameResult의 값 수정

  기존의 draw 값은 가위바위보에서 서로 낸 게 같은 것을 의미하였습니다. 하지만 묵찌빠에서 draw 값을 그대로 쓸 경우 서로 같은 걸 냈더라도 비겼다는 의미로 읽혀서 네이밍을 바꾸어주어야겠다는 고민을 했습니다.

  > 해결 방법:  GameResult의 값 draw를 값 same으로 수정하였습니다.
  >
  > 가위바위보에서는 서로 낸 게 ''같은'' 게 비긴 거고 묵찌빠에서는 서로 낸 게 ''같은'' 게 이긴 것이기 때문에 draw를 same으로 바꾸어 재사용성을 높였습니다.