### PR TITLE
[STEP 2] gundy, bella

### DIFF
--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		BFF1507228B37DEE001F3BFE /* RockPaperScissors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */; };
-		BFF1507428B48CB5001F3BFE /* MukChiBa.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF1507328B48CB5001F3BFE /* MukChiBa.swift */; };
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -26,7 +25,6 @@
 
 /* Begin PBXFileReference section */
 		BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissors.swift; sourceTree = "<group>"; };
-		BFF1507328B48CB5001F3BFE /* MukChiBa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukChiBa.swift; sourceTree = "<group>"; };
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -63,7 +61,6 @@
 			children = (
 				C7ABA0E0254EA63000B2367D /* main.swift */,
 				BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */,
-				BFF1507328B48CB5001F3BFE /* MukChiBa.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -127,7 +124,6 @@
 			files = (
 				BFF1507228B37DEE001F3BFE /* RockPaperScissors.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
-				BFF1507428B48CB5001F3BFE /* MukChiBa.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BFE7151128B60EB200BAC8A1 /* GameOver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7151028B60EB200BAC8A1 /* GameOver.swift */; };
+		BFE7151328B60EC500BAC8A1 /* GameJudgment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7151228B60EC500BAC8A1 /* GameJudgment.swift */; };
+		BFE7151528B60EDD00BAC8A1 /* UserSelect.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7151428B60EDD00BAC8A1 /* UserSelect.swift */; };
+		BFE7151728B60EEF00BAC8A1 /* GameText.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7151628B60EEF00BAC8A1 /* GameText.swift */; };
+		BFE7151928B60FAF00BAC8A1 /* Turn.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7151828B60FAF00BAC8A1 /* Turn.swift */; };
+		BFE7151B28B60FC400BAC8A1 /* MukChiBa.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7151A28B60FC400BAC8A1 /* MukChiBa.swift */; };
 		BFF1507228B37DEE001F3BFE /* RockPaperScissors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */; };
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 /* End PBXBuildFile section */
@@ -24,6 +30,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BFE7151028B60EB200BAC8A1 /* GameOver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameOver.swift; sourceTree = "<group>"; };
+		BFE7151228B60EC500BAC8A1 /* GameJudgment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameJudgment.swift; sourceTree = "<group>"; };
+		BFE7151428B60EDD00BAC8A1 /* UserSelect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelect.swift; sourceTree = "<group>"; };
+		BFE7151628B60EEF00BAC8A1 /* GameText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameText.swift; sourceTree = "<group>"; };
+		BFE7151828B60FAF00BAC8A1 /* Turn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Turn.swift; sourceTree = "<group>"; };
+		BFE7151A28B60FC400BAC8A1 /* MukChiBa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukChiBa.swift; sourceTree = "<group>"; };
 		BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissors.swift; sourceTree = "<group>"; };
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -61,6 +73,12 @@
 			children = (
 				C7ABA0E0254EA63000B2367D /* main.swift */,
 				BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */,
+				BFE7151A28B60FC400BAC8A1 /* MukChiBa.swift */,
+				BFE7151428B60EDD00BAC8A1 /* UserSelect.swift */,
+				BFE7151028B60EB200BAC8A1 /* GameOver.swift */,
+				BFE7151228B60EC500BAC8A1 /* GameJudgment.swift */,
+				BFE7151628B60EEF00BAC8A1 /* GameText.swift */,
+				BFE7151828B60FAF00BAC8A1 /* Turn.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -123,7 +141,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFF1507228B37DEE001F3BFE /* RockPaperScissors.swift in Sources */,
+				BFE7151728B60EEF00BAC8A1 /* GameText.swift in Sources */,
+				BFE7151128B60EB200BAC8A1 /* GameOver.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
+				BFE7151328B60EC500BAC8A1 /* GameJudgment.swift in Sources */,
+				BFE7151B28B60FC400BAC8A1 /* MukChiBa.swift in Sources */,
+				BFE7151528B60EDD00BAC8A1 /* UserSelect.swift in Sources */,
+				BFE7151928B60FAF00BAC8A1 /* Turn.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BFF1507228B37DEE001F3BFE /* RockPaperScissors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */; };
+		BFF1507428B48CB5001F3BFE /* MukChiBa.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF1507328B48CB5001F3BFE /* MukChiBa.swift */; };
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -25,6 +26,7 @@
 
 /* Begin PBXFileReference section */
 		BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissors.swift; sourceTree = "<group>"; };
+		BFF1507328B48CB5001F3BFE /* MukChiBa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukChiBa.swift; sourceTree = "<group>"; };
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -61,6 +63,7 @@
 			children = (
 				C7ABA0E0254EA63000B2367D /* main.swift */,
 				BFF1507128B37DEE001F3BFE /* RockPaperScissors.swift */,
+				BFF1507328B48CB5001F3BFE /* MukChiBa.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -124,6 +127,7 @@
 			files = (
 				BFF1507228B37DEE001F3BFE /* RockPaperScissors.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
+				BFF1507428B48CB5001F3BFE /* MukChiBa.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors/GameJudgment.swift
+++ b/RockPaperScissors/RockPaperScissors/GameJudgment.swift
@@ -6,7 +6,19 @@
 //
 
 enum GameJudgment: String {
-    case win = "이겼습니다!"
-    case lose = "졌습니다!"
-    case draw = "비겼습니다!"
+    case win
+    case lose
+    case draw
+    
+    var message: String {
+        switch self {
+        case .win:
+            return "이겼습니다!"
+        case .lose:
+            return "졌습니다!"
+        default:
+            return "비겼습니다!"
+        }
+    }
+    
 }

--- a/RockPaperScissors/RockPaperScissors/GameJudgment.swift
+++ b/RockPaperScissors/RockPaperScissors/GameJudgment.swift
@@ -5,8 +5,6 @@
 //  Created by Gundy, Bella
 //
 
-import Foundation
-
 enum GameJudgment: String {
     case win = "이겼습니다!"
     case lose = "졌습니다!"

--- a/RockPaperScissors/RockPaperScissors/GameJudgment.swift
+++ b/RockPaperScissors/RockPaperScissors/GameJudgment.swift
@@ -1,0 +1,14 @@
+//
+//  GameJudgment.swift
+//  RockPaperScissors
+//
+//  Created by Gundy, Bella
+//
+
+import Foundation
+
+enum GameJudgment: String {
+    case win = "이겼습니다!"
+    case lose = "졌습니다!"
+    case draw = "비겼습니다!"
+}

--- a/RockPaperScissors/RockPaperScissors/GameOver.swift
+++ b/RockPaperScissors/RockPaperScissors/GameOver.swift
@@ -5,8 +5,19 @@
 //  Created by Gundy, Bella
 //
 
-enum GameOver: String {
-    case exit = "게임 종료"
-    case userWin = "사용자의 승리!"
-    case computerWin = "컴퓨터의 승리!"
+enum GameOver {
+    case userWin
+    case computerWin
+    case exit
+    
+    var message: String {
+        switch self {
+        case .userWin:
+            return "사용자의 승리!"
+        case .computerWin:
+            return "컴퓨터의 승리!"
+        default:
+            return "게임 종료"
+        }
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/GameOver.swift
+++ b/RockPaperScissors/RockPaperScissors/GameOver.swift
@@ -1,0 +1,14 @@
+//
+//  GameOver.swift
+//  RockPaperScissors
+//
+//  Created by Gundy, Bella
+//
+
+import Foundation
+
+enum GameOver: String {
+    case exit = "게임 종료"
+    case userWin = "사용자의 승리!"
+    case computerWin = "컴퓨터의 승리!"
+}

--- a/RockPaperScissors/RockPaperScissors/GameOver.swift
+++ b/RockPaperScissors/RockPaperScissors/GameOver.swift
@@ -5,8 +5,6 @@
 //  Created by Gundy, Bella
 //
 
-import Foundation
-
 enum GameOver: String {
     case exit = "게임 종료"
     case userWin = "사용자의 승리!"

--- a/RockPaperScissors/RockPaperScissors/GameText.swift
+++ b/RockPaperScissors/RockPaperScissors/GameText.swift
@@ -5,8 +5,6 @@
 //  Created by Gundy, Bella
 //
 
-import Foundation
-
 enum GameText: String{
     case start = "가위(1), 바위(2), 보(3)! <종료 : 0> : "
     case caution = "잘못된 입력입니다. 다시 시도해주세요."

--- a/RockPaperScissors/RockPaperScissors/GameText.swift
+++ b/RockPaperScissors/RockPaperScissors/GameText.swift
@@ -1,0 +1,13 @@
+//
+//  GameText.swift
+//  RockPaperScissors
+//
+//  Created by Gundy, Bella
+//
+
+import Foundation
+
+enum GameText: String{
+    case start = "가위(1), 바위(2), 보(3)! <종료 : 0> : "
+    case caution = "잘못된 입력입니다. 다시 시도해주세요."
+}

--- a/RockPaperScissors/RockPaperScissors/GameText.swift
+++ b/RockPaperScissors/RockPaperScissors/GameText.swift
@@ -5,7 +5,16 @@
 //  Created by Gundy, Bella
 //
 
-enum GameText: String{
-    case start = "가위(1), 바위(2), 보(3)! <종료 : 0> : "
-    case caution = "잘못된 입력입니다. 다시 시도해주세요."
+enum GameText {
+    case start
+    case caution
+    
+    func displayMessage() {
+        switch self {
+        case .start:
+            print("가위(1), 바위(2), 보(3)! <종료 : 0> : ", terminator: "")
+        case .caution:
+            print("잘못된 입력입니다. 다시 시도해주세요.")
+        }
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -1,9 +1,0 @@
-//
-//  MCP.swift
-//  RockPaperScissors
-//
-//  Created by 이준영 on 2022/08/23.
-//
-
-import Foundation
-

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -5,7 +5,7 @@
 //  Created by Gundy, Bella
 //
 
-class MukChiba: RockPaperScissors {
+final class MukChiba: RockPaperScissors {
 
     override func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
         let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
@@ -22,7 +22,7 @@ class MukChiba: RockPaperScissors {
         }
     }
     
-    fileprivate func startMukChiBa(attackTurn: Turn) {
+    private func startMukChiBa(attackTurn: Turn) {
         attackTurn.displayTurn()
         GameText.start.displayMessage()
         guard let inputtedUserNumber: Int = Int(bindUserInput()) else {
@@ -33,7 +33,7 @@ class MukChiba: RockPaperScissors {
         playMukChiba(inputtedUserNumber, attackTurn)
     }
     
-    fileprivate func playMukChiba(_ userNumber: Int, _ attackTurn: Turn) {
+    private func playMukChiba(_ userNumber: Int, _ attackTurn: Turn) {
         switch selectOption(userNumber) {
         case .exit:
             print(GameOver.exit.message)
@@ -45,7 +45,7 @@ class MukChiba: RockPaperScissors {
         }
     }
     
-    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Turn) {
+    private func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Turn) {
         let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
         case .win:

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -11,13 +11,13 @@ class MukChiba: RockPaperScissors {
         let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
         case .win:
-            print(GameJudgment.win.rawValue)
+            print(GameJudgment.win.message)
             startMukChiBa(attackTurn: .user)
         case .lose:
-            print(GameJudgment.lose.rawValue)
+            print(GameJudgment.lose.message)
             startMukChiBa(attackTurn: .computer)
         default:
-            print(GameJudgment.draw.rawValue)
+            print(GameJudgment.draw.message)
             startGame()
         }
     }

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -1,0 +1,64 @@
+//
+//  MukChiBa.swift
+//  RockPaperScissors
+//
+//  Created by Gundy, Bella
+//
+
+import Foundation
+
+class MukChiba: RockPaperScissors {
+    override func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
+        let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
+        switch differenceNumber {
+        case .win:
+            print(GameJudgment.win.rawValue)
+            startMukChiBa(attackTurn: .user)
+        case .lose:
+            print(GameJudgment.lose.rawValue)
+            startMukChiBa(attackTurn: .computer)
+        default:
+            print(GameJudgment.draw.rawValue)
+            startGame()
+        }
+    }
+    
+    fileprivate func startMukChiBa(attackTurn: Turn) {
+        let turn: String = attackTurn == .user ? "[사용자 턴]" : "[컴퓨터 턴]"
+        print("\(turn) \(GameText.start.rawValue)", terminator: "")
+        guard let inputtedUserNumber: Int = Int(bindUserInput()) else {
+            print(GameText.caution.rawValue)
+            startMukChiBa(attackTurn: .computer)
+            return
+        }
+        playMukChiba(inputtedUserNumber, attackTurn)
+    }
+    
+    fileprivate func playMukChiba(_ userNumber: Int, _ attackTurn: Turn) {
+        switch selectOption(userNumber) {
+        case .exit:
+            print(GameOver.exit.rawValue)
+        case .play:
+            compareNumbers(makeComputerNumber(), userNumber, attackTurn)
+        default:
+            print(GameText.caution.rawValue)
+            startMukChiBa(attackTurn: .computer)
+        }
+    }
+    
+    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Turn) {
+        let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
+        switch differenceNumber {
+        case .win:
+            startMukChiBa(attackTurn: .user)
+        case .lose:
+            startMukChiBa(attackTurn: .computer)
+        default:
+            if turn == .user {
+                print(GameOver.userWin.rawValue)
+            } else {
+                print(GameOver.computerWin.rawValue)
+            }
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -23,8 +23,7 @@ class MukChiba: RockPaperScissors {
     }
     
     fileprivate func startMukChiBa(attackTurn: Turn) {
-//        let turn: String = attackTurn == .user ? "[사용자 턴]" : "[컴퓨터 턴]"
-        print(attackTurn, terminator: " ")
+        attackTurn.displayTurn()
         GameText.start.displayMessage()
         guard let inputtedUserNumber: Int = Int(bindUserInput()) else {
             GameText.caution.displayMessage()

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -36,7 +36,7 @@ class MukChiba: RockPaperScissors {
     fileprivate func playMukChiba(_ userNumber: Int, _ attackTurn: Turn) {
         switch selectOption(userNumber) {
         case .exit:
-            print(GameOver.exit.rawValue)
+            print(GameOver.exit.message)
         case .play:
             compareNumbers(makeComputerNumber(), userNumber, attackTurn)
         default:
@@ -54,9 +54,9 @@ class MukChiba: RockPaperScissors {
             startMukChiBa(attackTurn: .computer)
         default:
             if turn == .user {
-                print(GameOver.userWin.rawValue)
+                print(GameOver.userWin.message)
             } else {
-                print(GameOver.computerWin.rawValue)
+                print(GameOver.computerWin.message)
             }
         }
     }

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -5,9 +5,8 @@
 //  Created by Gundy, Bella
 //
 
-import Foundation
-
 class MukChiba: RockPaperScissors {
+
     override func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
         let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
@@ -24,8 +23,8 @@ class MukChiba: RockPaperScissors {
     }
     
     fileprivate func startMukChiBa(attackTurn: Turn) {
-        let turn: String = attackTurn == .user ? "[사용자 턴]" : "[컴퓨터 턴]"
-        print("\(turn) \(GameText.start.rawValue)", terminator: "")
+//        let turn: String = attackTurn == .user ? "[사용자 턴]" : "[컴퓨터 턴]"
+        print("\(attackTurn) \(GameText.start.rawValue)", terminator: "")
         guard let inputtedUserNumber: Int = Int(bindUserInput()) else {
             print(GameText.caution.rawValue)
             startMukChiBa(attackTurn: .computer)

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -24,9 +24,10 @@ class MukChiba: RockPaperScissors {
     
     fileprivate func startMukChiBa(attackTurn: Turn) {
 //        let turn: String = attackTurn == .user ? "[사용자 턴]" : "[컴퓨터 턴]"
-        print("\(attackTurn) \(GameText.start.rawValue)", terminator: "")
+        print(attackTurn, terminator: " ")
+        GameText.start.displayMessage()
         guard let inputtedUserNumber: Int = Int(bindUserInput()) else {
-            print(GameText.caution.rawValue)
+            GameText.caution.displayMessage()
             startMukChiBa(attackTurn: .computer)
             return
         }
@@ -40,7 +41,7 @@ class MukChiba: RockPaperScissors {
         case .play:
             compareNumbers(makeComputerNumber(), userNumber, attackTurn)
         default:
-            print(GameText.caution.rawValue)
+            GameText.caution.displayMessage()
             startMukChiBa(attackTurn: .computer)
         }
     }

--- a/RockPaperScissors/RockPaperScissors/MukChiBa.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBa.swift
@@ -1,0 +1,9 @@
+//
+//  MCP.swift
+//  RockPaperScissors
+//
+//  Created by 이준영 on 2022/08/23.
+//
+
+import Foundation
+

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -27,7 +27,7 @@ class RockPaperScissors {
     func playRockPaperScissors(_ userNumber: Int) {
         switch selectOption(userNumber) {
         case .exit:
-            print(GameOver.exit.rawValue)
+            print(GameOver.exit.message)
         case .play:
             compareNumbers(makeComputerNumber(), userNumber)
         default:

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -56,11 +56,11 @@ class RockPaperScissors {
         let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
         case .win:
-            print(GameJudgment.win.rawValue)
+            print(GameJudgment.win.message)
         case .lose:
-            print(GameJudgment.lose.rawValue)
+            print(GameJudgment.lose.message)
         default:
-            print(GameJudgment.draw.rawValue)
+            print(GameJudgment.draw.message)
             startGame()
         }
     }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -57,13 +57,28 @@ class RockPaperScissors {
 }
 
 class MukChiba: RockPaperScissors {
+    override fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
+        let differenceNumber: Int = computerGameNumber - userGameNumber
+        switch differenceNumber {
+        case -2, 1:
+            print("이겼습니다!")
+            startMukChiba(attackTurn: true)
+        case -1, 2:
+            print("졌습니다!")
+            startMukChiba(attackTurn: false)
+        default:
+            print("비겼습니다!")
+            startGame()
+        }
+    }
+    
     fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Bool) {
         let differenceNumber: Int = computerGameNumber - userGameNumber
         switch differenceNumber {
         case -2, 1:
-            startMukChiba(true)
+            startMukChiba(attackTurn: true)
         case -1, 2:
-            startMukChiba(false)
+            startMukChiba(attackTurn: false)
         default:
             if turn == true {
                 print("사용자의 승리!")
@@ -73,7 +88,7 @@ class MukChiba: RockPaperScissors {
         }
     }
     
-    fileprivate func startMukChiba(_ attackTurn: Bool) {
+    fileprivate func startMukChiba(attackTurn: Bool) {
         let turn: String
         if attackTurn == true {
             turn = "[사용자 턴]"
@@ -83,9 +98,21 @@ class MukChiba: RockPaperScissors {
         print("\(turn) 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
         guard let inputedUserNumber: Int = Int(bindUserInput()) else {
             print("잘못된 입력입니다. 다시 시도해주세요.")
-            startMukChiba(false)
+            startMukChiba(attackTurn: false)
             return
         }
-//        playMukChiba()
+        playMukChiba(inputedUserNumber, attackTurn)
+    }
+    
+    fileprivate func playMukChiba(_ userNumber: Int, _ attackTurn: Bool) {
+        switch userNumber {
+        case 0:
+            print("게임 종료")
+        case 1, 2, 3:
+            compareNumbers(makeComputerNumber(), userNumber, attackTurn)
+        default:
+            print("잘못된 입력입니다. 다시 시도해주세요.")
+            startMukChiba(attackTurn: false)
+        }
     }
 }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -7,11 +7,26 @@
 
 import Foundation
 
+enum GameOver: String {
+    case exit = "게임 종료"
+    case userWin = "사용자의 승리!"
+    case computerWin = "컴퓨터의 승리!"
+}
+
+enum WinLoseDecision: String {
+    case win = "이겼습니다!"
+    case lose = "졌습니다!"
+    case draw = "비겼습니다!"
+}
+
 class RockPaperScissors {
+    let startText: String = "가위(1), 바위(2), 보(3)! <종료 : 0> : "
+    let cautionText: String = "잘못된 입력입니다. 다시 시도해주세요."
+    
     func startGame() {
-        print("가위(1), 바위(2), 보(3)! <종료 : 0> : ", terminator: "")
+        print(startText, terminator: "")
         guard let inputedUserNumber: Int = Int(bindUserInput()) else {
-            print("잘못된 입력입니다. 다시 시도해주세요.")
+            print(cautionText)
             startGame()
             return
         }
@@ -28,11 +43,11 @@ class RockPaperScissors {
     fileprivate func playRockPaperScissors(_ userNumber: Int) {
         switch userNumber {
         case 0:
-            print("게임 종료")
+            print()
         case 1, 2, 3:
             compareNumbers(makeComputerNumber(), userNumber)
         default:
-            print("잘못된 입력입니다. 다시 시도해주세요.")
+            print(cautionText)
             startGame()
         }
     }
@@ -45,12 +60,12 @@ class RockPaperScissors {
     fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
         let differenceNumber: Int = computerGameNumber - userGameNumber
         switch differenceNumber {
-        case -2, 1:
-            print("이겼습니다!")
+        case -2, 1 :
+            print(WinLoseDecision.win.rawValue)
         case -1, 2:
-            print("졌습니다!")
+            print(WinLoseDecision.lose.rawValue)
         default:
-            print("비겼습니다!")
+            print(WinLoseDecision.draw.rawValue)
             startGame()
         }
     }
@@ -61,13 +76,13 @@ class MukChiba: RockPaperScissors {
         let differenceNumber: Int = computerGameNumber - userGameNumber
         switch differenceNumber {
         case -2, 1:
-            print("이겼습니다!")
+            print(WinLoseDecision.win.rawValue)
             startMukChiba(attackTurn: true)
         case -1, 2:
-            print("졌습니다!")
+            print(WinLoseDecision.lose.rawValue)
             startMukChiba(attackTurn: false)
         default:
-            print("비겼습니다!")
+            print(WinLoseDecision.draw.rawValue)
             startGame()
         }
     }
@@ -81,9 +96,9 @@ class MukChiba: RockPaperScissors {
             startMukChiba(attackTurn: false)
         default:
             if turn == true {
-                print("사용자의 승리!")
+                print(GameOver.userWin.rawValue)
             } else {
-                print("컴퓨터의 승리!")
+                print(GameOver.computerWin.rawValue)
             }
         }
     }
@@ -95,9 +110,9 @@ class MukChiba: RockPaperScissors {
         } else {
             turn = "[컴퓨터 턴]"
         }
-        print("\(turn) 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
+        print("\(turn) \(startText)", terminator: "")
         guard let inputedUserNumber: Int = Int(bindUserInput()) else {
-            print("잘못된 입력입니다. 다시 시도해주세요.")
+            print(cautionText)
             startMukChiba(attackTurn: false)
             return
         }
@@ -107,11 +122,11 @@ class MukChiba: RockPaperScissors {
     fileprivate func playMukChiba(_ userNumber: Int, _ attackTurn: Bool) {
         switch userNumber {
         case 0:
-            print("게임 종료")
+            print(GameOver.exit)
         case 1, 2, 3:
             compareNumbers(makeComputerNumber(), userNumber, attackTurn)
         default:
-            print("잘못된 입력입니다. 다시 시도해주세요.")
+            print(cautionText)
             startMukChiba(attackTurn: false)
         }
     }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -24,7 +24,7 @@ class RockPaperScissors {
         return userInput
     }
     
-    func playRockPaperScissors(_ userNumber: Int) {
+    private func playRockPaperScissors(_ userNumber: Int) {
         switch selectOption(userNumber) {
         case .exit:
             print(GameOver.exit.message)

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -7,87 +7,67 @@
 
 import Foundation
 
-enum GameOver: String {
-    case exit = "게임 종료"
-    case userWin = "사용자의 승리!"
-    case computerWin = "컴퓨터의 승리!"
-}
-
-enum WinLoseDraw: String {
-    case win = "이겼습니다!"
-    case lose = "졌습니다!"
-    case draw = "비겼습니다!"
-}
-
-enum UserSelect {
-    case exit
-    case play
-    case error
-}
-
 class RockPaperScissors {
-    let startText: String = "가위(1), 바위(2), 보(3)! <종료 : 0> : "
-    let cautionText: String = "잘못된 입력입니다. 다시 시도해주세요."
     
     func startGame() {
-        print(startText, terminator: "")
-        guard let inputedUserNumber: Int = Int(bindUserInput()) else {
-            print(cautionText)
+        print(GameText.start.rawValue, terminator: "")
+        guard let inputtedUserNumber: Int = Int(bindUserInput()) else {
+            print(GameText.caution.rawValue)
             startGame()
             return
         }
-        playRockPaperScissors(inputedUserNumber)
+        playRockPaperScissors(inputtedUserNumber)
     }
     
-    fileprivate func bindUserInput() -> String {
+    func bindUserInput() -> String {
         guard let userInput = readLine() else {
             return bindUserInput()
         }
         return userInput
     }
     
-    fileprivate func playRockPaperScissors(_ userNumber: Int) {
+    func playRockPaperScissors(_ userNumber: Int) {
         switch selectOption(userNumber) {
         case .exit:
             print(GameOver.exit.rawValue)
         case .play:
             compareNumbers(makeComputerNumber(), userNumber)
         default:
-            print(cautionText)
+            print(GameText.caution)
             startGame()
         }
     }
     
-    fileprivate func selectOption(_ userNumber: Int) -> UserSelect {
+    func selectOption(_ userNumber: Int) -> UserSelect {
         switch userNumber {
         case 0:
             return .exit
         case 1, 2, 3:
             return .play
         default:
-            return .error
+            return .wrong
         }
     }
     
-    fileprivate func makeComputerNumber() -> Int {
+    func makeComputerNumber() -> Int {
         let computerNumber: Int = Int.random(in: 1...3)
         return computerNumber
     }
     
-    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
-        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
+    func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
+        let differenceNumber: GameJudgment = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
         case .win:
-            print(WinLoseDraw.win.rawValue)
+            print(GameJudgment.win.rawValue)
         case .lose:
-            print(WinLoseDraw.lose.rawValue)
+            print(GameJudgment.lose.rawValue)
         default:
-            print(WinLoseDraw.draw.rawValue)
+            print(GameJudgment.draw.rawValue)
             startGame()
         }
     }
     
-    fileprivate func makeResult(_ differenceNumber: Int) -> WinLoseDraw {
+    func makeResult(_ differenceNumber: Int) -> GameJudgment {
         switch differenceNumber {
         case -2, 1:
             return .win
@@ -95,68 +75,6 @@ class RockPaperScissors {
             return .lose
         default:
             return .draw
-        }
-    }
-    
-}
-
-class MukChiba: RockPaperScissors {
-    override fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
-        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
-        switch differenceNumber {
-        case .win:
-            print(WinLoseDraw.win.rawValue)
-            startMukChiBa(attackTurn: true)
-        case .lose:
-            print(WinLoseDraw.lose.rawValue)
-            startMukChiBa(attackTurn: false)
-        default:
-            print(WinLoseDraw.draw.rawValue)
-            startGame()
-        }
-    }
-    
-    fileprivate func startMukChiBa(attackTurn: Bool) {
-        let turn: String
-        if attackTurn == true {
-            turn = "[사용자 턴]"
-        } else {
-            turn = "[컴퓨터 턴]"
-        }
-        print("\(turn) \(startText)", terminator: "")
-        guard let inputedUserNumber: Int = Int(bindUserInput()) else {
-            print(cautionText)
-            startMukChiBa(attackTurn: false)
-            return
-        }
-        playMukChiba(inputedUserNumber, attackTurn)
-    }
-    
-    fileprivate func playMukChiba(_ userNumber: Int, _ attackTurn: Bool) {
-        switch selectOption(userNumber) {
-        case .exit:
-            print(GameOver.exit.rawValue)
-        case .play:
-            compareNumbers(makeComputerNumber(), userNumber, attackTurn)
-        default:
-            print(cautionText)
-            startMukChiBa(attackTurn: false)
-        }
-    }
-    
-    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Bool) {
-        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
-        switch differenceNumber {
-        case .win:
-            startMukChiBa(attackTurn: true)
-        case .lose:
-            startMukChiBa(attackTurn: false)
-        default:
-            if turn == true {
-                print(GameOver.userWin.rawValue)
-            } else {
-                print(GameOver.computerWin.rawValue)
-            }
         }
     }
 }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -106,33 +106,17 @@ class MukChiba: RockPaperScissors {
         switch differenceNumber {
         case .win:
             print(WinLoseDraw.win.rawValue)
-            startMukChiba(attackTurn: true)
+            startMukChiBa(attackTurn: true)
         case .lose:
             print(WinLoseDraw.lose.rawValue)
-            startMukChiba(attackTurn: false)
+            startMukChiBa(attackTurn: false)
         default:
             print(WinLoseDraw.draw.rawValue)
             startGame()
         }
     }
     
-    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Bool) {
-        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
-        switch differenceNumber {
-        case .win:
-            startMukChiba(attackTurn: true)
-        case .lose:
-            startMukChiba(attackTurn: false)
-        default:
-            if turn == true {
-                print(GameOver.userWin.rawValue)
-            } else {
-                print(GameOver.computerWin.rawValue)
-            }
-        }
-    }
-    
-    fileprivate func startMukChiba(attackTurn: Bool) {
+    fileprivate func startMukChiBa(attackTurn: Bool) {
         let turn: String
         if attackTurn == true {
             turn = "[사용자 턴]"
@@ -142,7 +126,7 @@ class MukChiba: RockPaperScissors {
         print("\(turn) \(startText)", terminator: "")
         guard let inputedUserNumber: Int = Int(bindUserInput()) else {
             print(cautionText)
-            startMukChiba(attackTurn: false)
+            startMukChiBa(attackTurn: false)
             return
         }
         playMukChiba(inputedUserNumber, attackTurn)
@@ -156,7 +140,23 @@ class MukChiba: RockPaperScissors {
             compareNumbers(makeComputerNumber(), userNumber, attackTurn)
         default:
             print(cautionText)
-            startMukChiba(attackTurn: false)
+            startMukChiBa(attackTurn: false)
+        }
+    }
+    
+    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Bool) {
+        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
+        switch differenceNumber {
+        case .win:
+            startMukChiBa(attackTurn: true)
+        case .lose:
+            startMukChiBa(attackTurn: false)
+        default:
+            if turn == true {
+                print(GameOver.userWin.rawValue)
+            } else {
+                print(GameOver.computerWin.rawValue)
+            }
         }
     }
 }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -19,6 +19,12 @@ enum WinLoseDecision: String {
     case draw = "비겼습니다!"
 }
 
+enum UserSelect {
+    case exit
+    case play
+    case error
+}
+
 class RockPaperScissors {
     let startText: String = "가위(1), 바위(2), 보(3)! <종료 : 0> : "
     let cautionText: String = "잘못된 입력입니다. 다시 시도해주세요."
@@ -41,14 +47,25 @@ class RockPaperScissors {
     }
     
     fileprivate func playRockPaperScissors(_ userNumber: Int) {
-        switch userNumber {
-        case 0:
-            print()
-        case 1, 2, 3:
+        switch selectOption(userNumber) {
+        case .exit:
+            print(GameOver.exit.rawValue)
+        case .play:
             compareNumbers(makeComputerNumber(), userNumber)
         default:
             print(cautionText)
             startGame()
+        }
+    }
+    
+    fileprivate func selectOption(_ userNumber: Int) -> UserSelect {
+        switch userNumber {
+        case 0:
+            return .exit
+        case 1, 2, 3:
+            return .play
+        default:
+            return .error
         }
     }
     

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -18,14 +18,14 @@ class RockPaperScissors {
         playGame(inputedUserNumber)
     }
 
-    private func bindUserInput() -> String {
+    fileprivate func bindUserInput() -> String {
         guard let userInput = readLine() else {
             return bindUserInput()
         }
         return userInput
     }
 
-    private func playGame(_ userNumber: Int) {
+    fileprivate func playGame(_ userNumber: Int) {
         switch userNumber {
         case 0:
             print("게임 종료")
@@ -37,18 +37,35 @@ class RockPaperScissors {
         }
     }
 
-    private func makeComputerNumber() -> Int {
+    fileprivate func makeComputerNumber() -> Int {
         let computerNumber: Int = Int.random(in: 1...3)
         return computerNumber
     }
 
-    private func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
+    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
         let differenceNumber: Int = computerGameNumber - userGameNumber
         switch differenceNumber {
         case -2, 1:
             print("이겼습니다!")
         case -1, 2:
             print("졌습니다!")
+        default:
+            print("비겼습니다!")
+            startGame()
+        }
+    }
+}
+
+class MukChiba: RockPaperScissors {
+    override fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
+        let differenceNumber: Int = computerGameNumber - userGameNumber
+        switch differenceNumber {
+        case -2, 1:
+            print("이겼습니다!")
+            // 묵찌빠 함수
+        case -1, 2:
+            print("졌습니다!")
+            // 묵찌빠 함수
         default:
             print("비겼습니다!")
             startGame()

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -15,17 +15,17 @@ class RockPaperScissors {
             startGame()
             return
         }
-        playGame(inputedUserNumber)
+        playRockPaperScissors(inputedUserNumber)
     }
-
+    
     fileprivate func bindUserInput() -> String {
         guard let userInput = readLine() else {
             return bindUserInput()
         }
         return userInput
     }
-
-    fileprivate func playGame(_ userNumber: Int) {
+    
+    fileprivate func playRockPaperScissors(_ userNumber: Int) {
         switch userNumber {
         case 0:
             print("게임 종료")
@@ -36,12 +36,12 @@ class RockPaperScissors {
             startGame()
         }
     }
-
+    
     fileprivate func makeComputerNumber() -> Int {
         let computerNumber: Int = Int.random(in: 1...3)
         return computerNumber
     }
-
+    
     fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
         let differenceNumber: Int = computerGameNumber - userGameNumber
         switch differenceNumber {
@@ -57,18 +57,35 @@ class RockPaperScissors {
 }
 
 class MukChiba: RockPaperScissors {
-    override fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
+    fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Bool) {
         let differenceNumber: Int = computerGameNumber - userGameNumber
         switch differenceNumber {
         case -2, 1:
-            print("이겼습니다!")
-            // 묵찌빠 함수
+            startMukChiba(true)
         case -1, 2:
-            print("졌습니다!")
-            // 묵찌빠 함수
+            startMukChiba(false)
         default:
-            print("비겼습니다!")
-            startGame()
+            if turn == true {
+                print("사용자의 승리!")
+            } else {
+                print("컴퓨터의 승리!")
+            }
         }
+    }
+    
+    fileprivate func startMukChiba(_ attackTurn: Bool) {
+        let turn: String
+        if attackTurn == true {
+            turn = "[사용자 턴]"
+        } else {
+            turn = "[컴퓨터 턴]"
+        }
+        print("\(turn) 묵(1), 찌(2), 빠(3)! <종료 : 0> : ", terminator: "")
+        guard let inputedUserNumber: Int = Int(bindUserInput()) else {
+            print("잘못된 입력입니다. 다시 시도해주세요.")
+            startMukChiba(false)
+            return
+        }
+//        playMukChiba()
     }
 }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -8,9 +8,9 @@
 class RockPaperScissors {
     
     func startGame() {
-        print(GameText.start.rawValue, terminator: "")
+        GameText.start.displayMessage()
         guard let inputtedUserNumber: Int = Int(bindUserInput()) else {
-            print(GameText.caution.rawValue)
+            GameText.caution.displayMessage()
             startGame()
             return
         }
@@ -31,7 +31,7 @@ class RockPaperScissors {
         case .play:
             compareNumbers(makeComputerNumber(), userNumber)
         default:
-            print(GameText.caution)
+            GameText.caution.displayMessage()
             startGame()
         }
     }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -5,8 +5,6 @@
 //  Created by Gundy, Bella
 //
 
-import Foundation
-
 class RockPaperScissors {
     
     func startGame() {

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -13,7 +13,7 @@ enum GameOver: String {
     case computerWin = "컴퓨터의 승리!"
 }
 
-enum WinLoseDecision: String {
+enum WinLoseDraw: String {
     case win = "이겼습니다!"
     case lose = "졌습니다!"
     case draw = "비겼습니다!"
@@ -75,41 +75,53 @@ class RockPaperScissors {
     }
     
     fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
-        let differenceNumber: Int = computerGameNumber - userGameNumber
+        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
-        case -2, 1 :
-            print(WinLoseDecision.win.rawValue)
-        case -1, 2:
-            print(WinLoseDecision.lose.rawValue)
+        case .win:
+            print(WinLoseDraw.win.rawValue)
+        case .lose:
+            print(WinLoseDraw.lose.rawValue)
         default:
-            print(WinLoseDecision.draw.rawValue)
+            print(WinLoseDraw.draw.rawValue)
             startGame()
         }
     }
+    
+    fileprivate func makeResult(_ differenceNumber: Int) -> WinLoseDraw {
+        switch differenceNumber {
+        case -2, 1:
+            return .win
+        case -1, 2:
+            return .lose
+        default:
+            return .draw
+        }
+    }
+    
 }
 
 class MukChiba: RockPaperScissors {
     override fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int) {
-        let differenceNumber: Int = computerGameNumber - userGameNumber
+        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
-        case -2, 1:
-            print(WinLoseDecision.win.rawValue)
+        case .win:
+            print(WinLoseDraw.win.rawValue)
             startMukChiba(attackTurn: true)
-        case -1, 2:
-            print(WinLoseDecision.lose.rawValue)
+        case .lose:
+            print(WinLoseDraw.lose.rawValue)
             startMukChiba(attackTurn: false)
         default:
-            print(WinLoseDecision.draw.rawValue)
+            print(WinLoseDraw.draw.rawValue)
             startGame()
         }
     }
     
     fileprivate func compareNumbers(_ computerGameNumber: Int, _ userGameNumber: Int, _ turn: Bool) {
-        let differenceNumber: Int = computerGameNumber - userGameNumber
+        let differenceNumber: WinLoseDraw = makeResult(computerGameNumber - userGameNumber)
         switch differenceNumber {
-        case -2, 1:
+        case .win:
             startMukChiba(attackTurn: true)
-        case -1, 2:
+        case .lose:
             startMukChiba(attackTurn: false)
         default:
             if turn == true {
@@ -137,10 +149,10 @@ class MukChiba: RockPaperScissors {
     }
     
     fileprivate func playMukChiba(_ userNumber: Int, _ attackTurn: Bool) {
-        switch userNumber {
-        case 0:
-            print(GameOver.exit)
-        case 1, 2, 3:
+        switch selectOption(userNumber) {
+        case .exit:
+            print(GameOver.exit.rawValue)
+        case .play:
             compareNumbers(makeComputerNumber(), userNumber, attackTurn)
         default:
             print(cautionText)

--- a/RockPaperScissors/RockPaperScissors/Turn.swift
+++ b/RockPaperScissors/RockPaperScissors/Turn.swift
@@ -1,0 +1,13 @@
+//
+//  Turn.swift
+//  RockPaperScissors
+//
+//  Created by Gundy, Bella
+//
+
+import Foundation
+
+enum Turn {
+    case user
+    case computer
+}

--- a/RockPaperScissors/RockPaperScissors/Turn.swift
+++ b/RockPaperScissors/RockPaperScissors/Turn.swift
@@ -5,8 +5,6 @@
 //  Created by Gundy, Bella
 //
 
-import Foundation
-
 enum Turn {
     case user
     case computer

--- a/RockPaperScissors/RockPaperScissors/Turn.swift
+++ b/RockPaperScissors/RockPaperScissors/Turn.swift
@@ -8,4 +8,13 @@
 enum Turn {
     case user
     case computer
+    
+    func displayTurn() {
+        switch self {
+        case .user:
+            print("[사용자 턴]", terminator: " ")
+        case .computer:
+            print("[컴퓨터 턴]", terminator: " ")
+        }
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/UserSelect.swift
+++ b/RockPaperScissors/RockPaperScissors/UserSelect.swift
@@ -1,0 +1,14 @@
+//
+//  UserSelect.swift
+//  RockPaperScissors
+//
+//  Created by Gundy, Bella
+//
+
+import Foundation
+
+enum UserSelect {
+    case exit
+    case play
+    case wrong
+}

--- a/RockPaperScissors/RockPaperScissors/UserSelect.swift
+++ b/RockPaperScissors/RockPaperScissors/UserSelect.swift
@@ -5,8 +5,6 @@
 //  Created by Gundy, Bella
 //
 
-import Foundation
-
 enum UserSelect {
     case exit
     case play

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -8,7 +8,7 @@ import Foundation
 
 let rockPaperScissorsGame: RockPaperScissors = .init()
 
-//rockPaperScissorsGame.startGame()
+rockPaperScissorsGame.startGame()
 
 let mukChibaGame: MukChiba = .init()
 

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -4,12 +4,6 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation
-
-let rockPaperScissorsGame: RockPaperScissors = .init()
-
-rockPaperScissorsGame.startGame()
-
 let mukChibaGame: MukChiba = .init()
 
 mukChibaGame.startGame()

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -8,4 +8,8 @@ import Foundation
 
 let rockPaperScissorsGame: RockPaperScissors = .init()
 
-rockPaperScissorsGame.
+//rockPaperScissorsGame.startGame()
+
+let mukChibaGame: MukChiba = .init()
+
+mukChibaGame.startGame()

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -8,7 +8,7 @@ import Foundation
 
 let rockPaperScissorsGame: RockPaperScissors = .init()
 
-rockPaperScissorsGame.startGame()
+//rockPaperScissorsGame.startGame()
 
 let mukChibaGame: MukChiba = .init()
 

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -8,4 +8,4 @@ import Foundation
 
 let rockPaperScissorsGame: RockPaperScissors = .init()
 
-rockPaperScissorsGame.startGame()
+rockPaperScissorsGame.


### PR DESCRIPTION
@Groot-94
[STEP 2]도 리뷰 잘 부탁드립니다! 🙌
고민했던점과 조언이필요한점 외에도 피드백 왕창왕창 부탁드립니다! 🙏🏼
main.swift에서 가위바위보의 인스턴스인 `rockPaperScissorsGame`와 묵찌빠의 인스턴스인 `mukChibaGame` 모두 `startGame` 메서드를 사용하게끔 작성했는데요, 이는 저희가 의도한 기존 타입을 수정하지 않고 상속받아 재정의하는 부분을 잘 표현하기 위해서 이렇게 작성했습니다. 같은 `startGame` 메서드를 호출해도 어떻게 결과가 달라지는지 명확히 보일 것이라고 생각했습니다.

### 고민했던 점

- #### `override`
    - 기존에 정의한 다른 함수들은 그대로 사용하며 `compareNumbers`의 경우에만 묵찌빠를 할 때 누구의 턴인지 분기처리하기 위해 재정의했습니다. 처음에 클래스로 타입을 결정한 이유도 기존 코드를 건들지 않고 상속받아 재정의하기 위함이었기때문에 그렇게 했습니다.
- #### `overload`
    - `compareNumbers` 함수의 기능이 가위바위보와 묵찌빠에서 일부 수정이 필요했는데, 기능이 닮아 네이밍을 새로 하지않고 `overload`를 선택했습니다.
 - #### 출력문구 분기처리
    - 조건문을 사용해 누구의 묵찌빠 공격 턴인지에 따라 "[누구의 턴] 묵(1), 찌(2), 빠(3)! <종료 : 0>" 까지 모두 출력하는 방법을 생각했었는데, 매개변수 `attackTurn`을 `Bool`타입으로 받아 조건문으로 나누어 문자열보간법을 사용해 가독성이 더 좋다고 생각하는 코드가 되었습니다.
- #### 타입의 사용
    - 기존에는 STEP 2를 진행하면서 비슷한 기능의 함수를 조금만 손봐서 진행할 생각이었으나, 타입의 개념을 바탕으로 사용해보니 중복 코드를 줄일 수 있었습니다. 그리고 타입 단위로 함수들을 묶어서 정체성을 더욱 명확히하였습니다. 은닉화를 해 인스턴스의 메서드 호출시 `startGame`만 보이게끔 설정할 수 있는 점도 타입의 장점이었습니다.

### 해결이 되지 않은 점

- #### 파일 분리
    - 타입 단위로 파일을 분리하고 싶었으나, 메서드의 은닉화 과정을 거쳤기 때문에 상속으로 `override`를 하려면 최소한 접근 수준을 `fileprivate`으로 설정하고 같은 파일에서 상속받는 타입인 `MukChiba`를 정의해야 했습니다. `override`할 메서드만이라도 은닉화를 안했다면 파일 분리는 가능했을텐데, 그 메서드도 은닉하고 싶어서 이렇게 진행했습니다. 이 부분은 조언이 필요한 건지 해결이 되지 않은 것인지 고민이 되지만 해결이 되지 않은 부분으로 작성하였습니다.

### 조언이 필요한 점

- #### `overload`
    - STEP 2를 진행하며`compareNumbers` 함수를 `overload`했는데, 이런 경우 다른 네이밍을 해서 함수를 정의하는 것이 나을까요?
- #### `magicLiteral`, `magicNumber`
    - 저희는 현재 상수나 변수에 할당을 한 뒤에 매개변수로 이용하고 있는데, 이런 부분에서 할당하지 않고 반환이 있는 함수 등을 바로 매개변수로 사용하는 것을 `magic`으로 이해했습니다. 하지만 키워드 문제인지 구글링을 하여도 참고할 자료가 마땅치않아 적용단계까진 가지 못했는데, 어떻게 활용하면 좋을지 조언을 부탁합니다. 만약 저희가 이해한 게 맞다면 `compareNumbers`에서 컴퓨터 임의의 수로 `magicNumber`를 활용하고 있는 것이 맞나요? 또 혹시 참고할만한 링크가 있다면 여쭤볼 수 있을까요?