### PR TITLE
[Step 2] 감자, som

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,124 @@
 
 ### 묵찌빠 프로젝트 저장소
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+# **1. 제목: 묵찌빠 게임**👊✌️🖐
+
+# **2. 소개**
+
+- 가위바위보를 먼저 진행하고, 이긴 사람이 턴을 가집니다. (비길 경우, 가위바위보 계속 진행)
+- 묵찌빠를 비길 때까지 계속 진행하는 동안, 이긴 사람이 턴을 가집니다.
+- 해당 사람의 턴에서 비길 경우, 해당 사람이 승리하게 됩니다.
+
+# 3. **팀원**
+|![KakaoTalk_Image_2022-08-19-11-48-18](https://user-images.githubusercontent.com/94514250/186832043-e0a731db-4f9f-437b-8609-a132c0703bfc.png)|![포차코](https://user-images.githubusercontent.com/94514250/186832089-4b62cf4a-e0e9-4bc9-b908-97837bff96c4.png)|
+|:---:|:---:|
+|감자|som|
+
+
+# 4. **타임라인**
+<img width="1065" alt="스크린샷 2022-08-26 오후 2 37 08" src="https://user-images.githubusercontent.com/94514250/186832638-6079bac7-adb8-47c7-a577-6dbda2daa9a3.png">
+<img width="1060" alt="스크린샷 2022-08-26 오후 2 37 24" src="https://user-images.githubusercontent.com/94514250/186832551-97563e90-bb24-42ec-ae2b-d33132f7e38b.png">
+<img width="1055" alt="스크린샷 2022-08-26 오후 2 37 34" src="https://user-images.githubusercontent.com/94514250/186832563-ab46e95d-1397-41d2-a539-6bc0dec6495d.png">
+<img width="1056" alt="스크린샷 2022-08-26 오후 2 37 42" src="https://user-images.githubusercontent.com/94514250/186832570-6636596f-aa2a-435b-b195-0376d2c0c498.png">
+<img width="1063" alt="스크린샷 2022-08-26 오후 2 37 50" src="https://user-images.githubusercontent.com/94514250/186832581-35fb95a5-e4ad-428a-8917-1747680637c0.png">
+
+# 5. **시각화된 프로젝트 구조**
+![제목 없는 다이어그램 drawio](https://user-images.githubusercontent.com/94514250/186832719-d333d226-c014-49da-a3ea-664a604b0878.png)
+
+# 6. **실행 화면**
+1. 정상적으로 게임이 작동되는 경우
+<img width="303" alt="스크린샷 2022-08-26 오후 2 40 45" src="https://user-images.githubusercontent.com/94514250/186832812-5804c701-3362-4650-8ef2-c9afde24be9e.png">
+
+2. 잘못된 수를 입력한 경우
+<img width="275" alt="스크린샷 2022-08-26 오후 2 40 04" src="https://user-images.githubusercontent.com/94514250/186832885-21e05fff-4e16-45bf-b99e-80dc05e4c69d.png">
+
+3. 게임을 종료한 경우
+<img width="245" alt="스크린샷 2022-08-26 오후 2 39 47" src="https://user-images.githubusercontent.com/94514250/186832906-068dd688-518d-46cb-9b5e-1aaeacb63f37.png">
+
+
+# 7. **트러블 슈팅**
+
+1. 반복문 VS 재귀함수<br>
+게임의 반복성을 위해 `while 반복문`으로 할지, `재귀함수`로 할지 고민을 했습니다. 일단 `while 루프`를 도는 방법이 메서드들을 파악하기 어려워지는 거 같아 `재귀함수`로 선택했습니다.
+
+2. 옵셔널 언래핑에 대한 고민
+
+```swift
+func inputUserNumber() -> String {
+    guard let inputUserNumber = readLine(), inputUserNumber.isEmpty == false else {
+        return "입력된 값이 없습니다."
+    }
+    userNumber = Int(inputUserNumber) ?? 4
+        
+    return inputUserNumber
+}
+```
+
+위의 코드에서 `옵셔널 병합 연산자`를 통해 `4라는 Int형 값`을 주었습니다. 이 부분이 언래핑 절차에 부적절한 코드인 거 같아서 정말 많은 고민 끝에 코드를 수정하게 되었습니다.
+
+```swift
+func inputUserNumber() -> Int? {
+    guard let inputUserNumber = readLine(), inputUserNumber.isEmpty == false else {
+        print("입력된 값이 없습니다.")
+        return inputUserNumber()
+    }
+
+    let inputUserNumberToInt = Int(inputUserNumber)
+
+    return inputUserNumberToInt
+}
+```
+
+som은 `Int?` 반환값 사용이 익숙치 않아서 `inputUserNumber()` 메서드 안에서 언래핑을 실행해야 한다는 생각 때문에, 이 부분에서 감자와 논의를 많이 한 거 같습니다. `옵셔널 언래핑`도 기능이라고 볼 수 있기 때문에 다른 메서드로 기능을 옮기는 과정으로 결정했습니다.
+
+3. `judgeWinOrLose` 메서드<br>
+처음에는 `inputUserNumber()`에서 가져온 `userNumber`과 1...3의 랜덤숫자를 가지는 `computerRandomNumber`의 차이값을 사용하여 `switch구문`을 만들었습니다.
+
+```swift
+func judgeWinOrLose() {
+    switch userNumber - computerNumber {
+    case -1, 2:
+        return "졌습니다!"
+    case -2, 1:
+        return "이겼습니다!"
+    case 0:
+        return "비겼습니다!"
+    default:
+        return "잘못된 입력입니다. 다시 시도해주세요."
+    }
+}
+```
+
+제작자가 아닌 다른 사람들이 코드를 보았을 때, 직관적으로 와닿지 않는 점을 고려하여 `RPS 열거형`을 넣어보기로 했습니다.
+
+```swift
+switch userRPS {
+    case .scissors:
+        if computerRPS == .paper {
+            gameResult = .win
+        } else if computerRPS == .rock {
+            gameResult = .lose
+        }
+    case .rock:
+        if computerRPS == .scissors {
+            gameResult = .win
+        } else if computerRPS == .paper {
+            gameResult = .lose
+        }
+    case .paper:
+        if computerRPS == .rock {
+            gameResult = .win
+        } else if computerRPS == .scissors {
+            gameResult = .lose
+        }
+    }
+```
+
+`case` 안에 들어간 `조건문`을 `삼항연산자`로 구현할까 고민했지만, `if 조건문`이 더 직관적으로 표현될 거 같아 `조건문`을 사용했습니다.
+
+# 8. 참고한 문서
+
+[Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) <br>
+[재귀함수 (반복문과 비교)](https://jaemuyeo.github.io/swift/RecursionFunction/) <br>
+[[Algorithm] 재귀와 반복문](https://velog.io/@gillog/Algorithm-%EC%9E%AC%EA%B7%80%EC%99%80-%EB%B0%98%EB%B3%B5%EB%AC%B8)
 

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		AE0B9F9A28B4661C00718C11 /* GameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B9F9928B4661C00718C11 /* GameResult.swift */; };
 		AE0B9F9C28B4C0E500718C11 /* GameComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B9F9B28B4C0E500718C11 /* GameComment.swift */; };
+		AE9486FD28B77D9C000C0A64 /* Turn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9486FC28B77D9C000C0A64 /* Turn.swift */; };
 		BB483B2428B383F40003F04F /* RockPaperScissorsGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB483B2328B383F40003F04F /* RockPaperScissorsGame.swift */; };
 		BB483B2628B384400003F04F /* RockPaperScissors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB483B2528B384400003F04F /* RockPaperScissors.swift */; };
 		BBE124B528B77CB90035C401 /* MukChiBba.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE124B428B77CB90035C401 /* MukChiBba.swift */; };
@@ -30,6 +31,7 @@
 /* Begin PBXFileReference section */
 		AE0B9F9928B4661C00718C11 /* GameResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResult.swift; sourceTree = "<group>"; };
 		AE0B9F9B28B4C0E500718C11 /* GameComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameComment.swift; sourceTree = "<group>"; };
+		AE9486FC28B77D9C000C0A64 /* Turn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Turn.swift; sourceTree = "<group>"; };
 		BB483B2328B383F40003F04F /* RockPaperScissorsGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsGame.swift; sourceTree = "<group>"; };
 		BB483B2528B384400003F04F /* RockPaperScissors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissors.swift; sourceTree = "<group>"; };
 		BBE124B428B77CB90035C401 /* MukChiBba.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukChiBba.swift; sourceTree = "<group>"; };
@@ -73,6 +75,7 @@
 				AE0B9F9928B4661C00718C11 /* GameResult.swift */,
 				AE0B9F9B28B4C0E500718C11 /* GameComment.swift */,
 				BBE124B428B77CB90035C401 /* MukChiBba.swift */,
+				AE9486FC28B77D9C000C0A64 /* Turn.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -140,6 +143,7 @@
 				BB483B2628B384400003F04F /* RockPaperScissors.swift in Sources */,
 				BBE124B528B77CB90035C401 /* MukChiBba.swift in Sources */,
 				AE0B9F9C28B4C0E500718C11 /* GameComment.swift in Sources */,
+				AE9486FD28B77D9C000C0A64 /* Turn.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AE0B9F9C28B4C0E500718C11 /* GameComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B9F9B28B4C0E500718C11 /* GameComment.swift */; };
 		BB483B2428B383F40003F04F /* RockPaperScissorsGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB483B2328B383F40003F04F /* RockPaperScissorsGame.swift */; };
 		BB483B2628B384400003F04F /* RockPaperScissors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB483B2528B384400003F04F /* RockPaperScissors.swift */; };
+		BBE124B528B77CB90035C401 /* MukChiBba.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE124B428B77CB90035C401 /* MukChiBba.swift */; };
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -31,6 +32,7 @@
 		AE0B9F9B28B4C0E500718C11 /* GameComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameComment.swift; sourceTree = "<group>"; };
 		BB483B2328B383F40003F04F /* RockPaperScissorsGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsGame.swift; sourceTree = "<group>"; };
 		BB483B2528B384400003F04F /* RockPaperScissors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissors.swift; sourceTree = "<group>"; };
+		BBE124B428B77CB90035C401 /* MukChiBba.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukChiBba.swift; sourceTree = "<group>"; };
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -70,6 +72,7 @@
 				BB483B2528B384400003F04F /* RockPaperScissors.swift */,
 				AE0B9F9928B4661C00718C11 /* GameResult.swift */,
 				AE0B9F9B28B4C0E500718C11 /* GameComment.swift */,
+				BBE124B428B77CB90035C401 /* MukChiBba.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -135,6 +138,7 @@
 				BB483B2428B383F40003F04F /* RockPaperScissorsGame.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
 				BB483B2628B384400003F04F /* RockPaperScissors.swift in Sources */,
+				BBE124B528B77CB90035C401 /* MukChiBba.swift in Sources */,
 				AE0B9F9C28B4C0E500718C11 /* GameComment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		AE0B9F9A28B4661C00718C11 /* GameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B9F9928B4661C00718C11 /* GameResult.swift */; };
 		AE0B9F9C28B4C0E500718C11 /* GameComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B9F9B28B4C0E500718C11 /* GameComment.swift */; };
 		AE9486FD28B77D9C000C0A64 /* Turn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9486FC28B77D9C000C0A64 /* Turn.swift */; };
-		BB483B2428B383F40003F04F /* RockPaperScissorsGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB483B2328B383F40003F04F /* RockPaperScissorsGame.swift */; };
+		BB483B2428B383F40003F04F /* MukChiBbaGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB483B2328B383F40003F04F /* MukChiBbaGame.swift */; };
 		BB483B2628B384400003F04F /* RockPaperScissors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB483B2528B384400003F04F /* RockPaperScissors.swift */; };
 		BBE124B528B77CB90035C401 /* MukChiBba.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE124B428B77CB90035C401 /* MukChiBba.swift */; };
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
@@ -32,7 +32,7 @@
 		AE0B9F9928B4661C00718C11 /* GameResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResult.swift; sourceTree = "<group>"; };
 		AE0B9F9B28B4C0E500718C11 /* GameComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameComment.swift; sourceTree = "<group>"; };
 		AE9486FC28B77D9C000C0A64 /* Turn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Turn.swift; sourceTree = "<group>"; };
-		BB483B2328B383F40003F04F /* RockPaperScissorsGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsGame.swift; sourceTree = "<group>"; };
+		BB483B2328B383F40003F04F /* MukChiBbaGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukChiBbaGame.swift; sourceTree = "<group>"; };
 		BB483B2528B384400003F04F /* RockPaperScissors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissors.swift; sourceTree = "<group>"; };
 		BBE124B428B77CB90035C401 /* MukChiBba.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukChiBba.swift; sourceTree = "<group>"; };
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -70,7 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				C7ABA0E0254EA63000B2367D /* main.swift */,
-				BB483B2328B383F40003F04F /* RockPaperScissorsGame.swift */,
+				BB483B2328B383F40003F04F /* MukChiBbaGame.swift */,
 				BB483B2528B384400003F04F /* RockPaperScissors.swift */,
 				AE0B9F9928B4661C00718C11 /* GameResult.swift */,
 				AE0B9F9B28B4C0E500718C11 /* GameComment.swift */,
@@ -138,7 +138,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE0B9F9A28B4661C00718C11 /* GameResult.swift in Sources */,
-				BB483B2428B383F40003F04F /* RockPaperScissorsGame.swift in Sources */,
+				BB483B2428B383F40003F04F /* MukChiBbaGame.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
 				BB483B2628B384400003F04F /* RockPaperScissors.swift in Sources */,
 				BBE124B528B77CB90035C401 /* MukChiBba.swift in Sources */,

--- a/RockPaperScissors/RockPaperScissors/GameComment.swift
+++ b/RockPaperScissors/RockPaperScissors/GameComment.swift
@@ -5,6 +5,8 @@ enum GameComment: String {
     case gameWin = "이겼습니다!"
     case gameLose = "졌습니다!"
     case gameDraw = "비겼습니다!"
+    case userTurn = "사용자의 턴입니다."
+    case computerTurn = "컴퓨터의 턴입니다."
     case gameRockPaperScissorsMenu = "가위(1), 바위(2), 보(3)! <종료 : 0>: "
     case gameMukChiBbaMenu = "묵(1), 찌(2), 빠(3)! <종료 : 0> : "
     case none = "입력된 값이 없습니다."

--- a/RockPaperScissors/RockPaperScissors/GameComment.swift
+++ b/RockPaperScissors/RockPaperScissors/GameComment.swift
@@ -5,7 +5,8 @@ enum GameComment: String {
     case gameWin = "이겼습니다!"
     case gameLose = "졌습니다!"
     case gameDraw = "비겼습니다!"
-    case gameMenu = "가위(1), 바위(2), 보(3)! <종료 : 0>: "
+    case gameRPSMenu = "가위(1), 바위(2), 보(3)! <종료 : 0>: "
+    case gameMCBMenu = "묵(1), 찌(2), 빠(3)! <종료 : 0> : "
     case none = "입력된 값이 없습니다."
     case gameOver = "게임 종료"
 }

--- a/RockPaperScissors/RockPaperScissors/GameComment.swift
+++ b/RockPaperScissors/RockPaperScissors/GameComment.swift
@@ -5,8 +5,8 @@ enum GameComment: String {
     case gameWin = "이겼습니다!"
     case gameLose = "졌습니다!"
     case gameDraw = "비겼습니다!"
-    case gameRPSMenu = "가위(1), 바위(2), 보(3)! <종료 : 0>: "
-    case gameMCBMenu = "묵(1), 찌(2), 빠(3)! <종료 : 0> : "
+    case gameRockPaperScissorsMenu = "가위(1), 바위(2), 보(3)! <종료 : 0>: "
+    case gameMukChiBbaMenu = "묵(1), 찌(2), 빠(3)! <종료 : 0> : "
     case none = "입력된 값이 없습니다."
     case gameOver = "게임 종료"
 }

--- a/RockPaperScissors/RockPaperScissors/MukChiBba.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBba.swift
@@ -1,0 +1,7 @@
+//  Created by 감자 and som on 2022/08/22.
+
+enum MukChiBba: Int {
+    case muk = 1
+    case chi = 2
+    case bba = 3
+}

--- a/RockPaperScissors/RockPaperScissors/MukChiBba.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBba.swift
@@ -4,4 +4,10 @@ enum MukChiBba: Int {
     case muk = 1
     case chi = 2
     case bba = 3
+    
+    static func random() -> MukChiBba {
+        let mcb: [Self] = [.muk, .chi, .bba]
+        let randomNumber = Int.random(in: 0...2)
+        return mcb[randomNumber]
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
@@ -14,12 +14,11 @@ struct MukChiBbaGame {
             return
         }
         
-        guard let tupleRockPaperScissors =  convertRockPaperScissors(to: userNumber) else {
+        guard let (userRPS, computerRPS) =  convertRockPaperScissors(to: userNumber) else {
             return play()
         }
         
-        let userGameResult = judgeWinOrLoseAtRockPaperScissors(RPS:
-        tupleRockPaperScissors)
+        let userGameResult = judgeWinOrLoseAtRockPaperScissors(RPS: (userRPS, computerRPS))
         
         showResult(userGameResult)
     }
@@ -37,11 +36,11 @@ struct MukChiBbaGame {
             return
         }
         
-        guard let tupleMukChiBba = convertMukChiBba(to: userNumber) else {
+        guard let (userMCB, computerMCB) = convertMukChiBba(to: userNumber) else {
             return playMukChiBba(turn: .computer)
         }
         
-        judgeWinOrLoseAtMukChiBba(MCB: tupleMukChiBba, to: turn)
+        judgeWinOrLoseAtMukChiBba(MCB: (userMCB, computerMCB), to: turn)
     }
     
     private func showRockPaperScissorsMenu() {

--- a/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
@@ -69,20 +69,20 @@ struct MukChiBbaGame {
     
     private func convertRockPaperScissors(to inputNumber: Int)
     -> (RockPaperScissors, RockPaperScissors)? {
-        guard let numberToRPS: RockPaperScissors = .init(rawValue: inputNumber),
-              let computerRPS: RockPaperScissors = .init(rawValue: Int.random(in: 1...3)) else {
+        guard let numberToRPS: RockPaperScissors = .init(rawValue: inputNumber) else {
             print(GameComment.retry.rawValue)
             return nil
         }
+        let computerRPS = RockPaperScissors.random()
         return (numberToRPS, computerRPS)
     }
     
     private func convertMukChiBba(to inputNumber: Int) -> (MukChiBba, MukChiBba)? {
-        guard let userNumberMCB: MukChiBba = .init(rawValue: inputNumber),
-              let computerMCB: MukChiBba = .init(rawValue: Int.random(in: 1...3)) else {
+        guard let userNumberMCB: MukChiBba = .init(rawValue: inputNumber) else {
             print(GameComment.retry.rawValue)
             return nil
         }
+        let computerMCB = MukChiBba.random()
         return (userNumberMCB, computerMCB)
     }
     

--- a/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
@@ -1,11 +1,12 @@
 //  Created by 감자 and som on 2022/08/22.
 
-struct RockPaperScissorsGame {
+struct MukChiBbaGame {
     func play() {
+        showRockPaperScissorsMenu()
+        
         guard let userNumber = inputUserNumber() else {
             print(GameComment.retry.rawValue)
-            play()
-            return
+            return play()
         }
         
         if checkEndGame(userNumber) {
@@ -13,23 +14,22 @@ struct RockPaperScissorsGame {
             return
         }
         
-        guard let compareRPS =  convertRPS(inputNumber: userNumber) else {
-            play()
-            return
+        guard let tupleRockPaperScissors =  convertRockPaperScissors(inputNumber: userNumber) else {
+            return play()
         }
         
-        let userGameResult = judgeWinOrLoseAtRPS(RPS: compareRPS)
+        let userGameResult = judgeWinOrLoseAtRockPaperScissors(RockPaperScissors:
+        tupleRockPaperScissors)
         
         showResult(userGameResult)
     }
     
-    func playMCB(turn: Turn) {
-        showMCBMenu(turn: turn)
+    private func playMukChiBba(turn: Turn) {
+        showMukChiBbaMenu(turn: turn)
         
         guard let userNumber = inputUserNumber() else {
             print(GameComment.retry.rawValue)
-            playMCB(turn: .computer)
-            return
+            return playMukChiBba(turn: .computer)
         }
         
         if checkEndGame(userNumber) {
@@ -37,28 +37,25 @@ struct RockPaperScissorsGame {
             return
         }
         
-        guard let compareMCB = convertMCB(inputNumber: userNumber) else {
-            playMCB(turn: .computer)
-            return
+        guard let tupleMukChiBba = convertMukChiBba(inputNumber: userNumber) else {
+            return playMukChiBba(turn: .computer)
         }
         
-        judgeWinOrLoseAtMCB(MCB: (userMCB, computerMCB), to: turn)
+        judgeWinOrLoseAtMukChiBba(MukChiBba: tupleMukChiBba, to: turn)
     }
     
-    private func showMenu() {
-        print(GameComment.gameRPSMenu.rawValue, terminator: "")
+    private func showRockPaperScissorsMenu() {
+        print(GameComment.gameRockPaperScissorsMenu.rawValue, terminator: "")
     }
     
-    private func showMCBMenu(turn: Turn) {
-        print("[\(turn.rawValue) 턴] \(GameComment.gameMCBMenu.rawValue)", terminator: "")
+    private func showMukChiBbaMenu(turn: Turn) {
+        print("[\(turn.rawValue) 턴] \(GameComment.gameMukChiBbaMenu.rawValue)", terminator: "")
     }
     
     private func inputUserNumber() -> Int? {
-        showMenu()
-        
         guard let inputUserNumber = readLine(), inputUserNumber.isEmpty == false else {
             print(GameComment.none.rawValue)
-            return inputUserNumber()
+            return nil
         }
         let inputUserNumberToInt = Int(inputUserNumber)
         return inputUserNumberToInt
@@ -71,7 +68,8 @@ struct RockPaperScissorsGame {
         return true
     }
     
-    private func convertRPS(inputNumber: Int) -> (RockPaperScissors, RockPaperScissors)? {
+    private func convertRockPaperScissors(inputNumber: Int)
+    -> (RockPaperScissors, RockPaperScissors)? {
         guard let numberToRPS: RockPaperScissors = .init(rawValue: inputNumber),
               let computerRPS: RockPaperScissors = .init(rawValue: Int.random(in: 1...3)) else {
             print(GameComment.retry.rawValue)
@@ -80,7 +78,7 @@ struct RockPaperScissorsGame {
         return (numberToRPS, computerRPS)
     }
     
-    private func convertMCB(inputNumber: Int) -> (MukChiBba, MukChiBba)? {
+    private func convertMukChiBba(inputNumber: Int) -> (MukChiBba, MukChiBba)? {
         guard let userNumberMCB: MukChiBba = .init(rawValue: inputNumber),
               let computerMCB: MukChiBba = .init(rawValue: Int.random(in: 1...3)) else {
             print(GameComment.retry.rawValue)
@@ -89,10 +87,12 @@ struct RockPaperScissorsGame {
         return (userNumberMCB, computerMCB)
     }
     
-    private func judgeWinOrLoseAtRPS(RPS: (RockPaperScissors, RockPaperScissors)) -> GameResult {
+    private func judgeWinOrLoseAtRockPaperScissors(
+        RockPaperScissors: (RockPaperScissors, RockPaperScissors)
+    ) -> GameResult {
         let gameResult: GameResult
         
-        switch RPS {
+        switch RockPaperScissors {
         case let (userRPS, computerRPS) where userRPS == computerRPS:
             gameResult = .draw
         case (.scissors, .paper), (.paper, .rock), (.rock, .scissors) :
@@ -103,16 +103,16 @@ struct RockPaperScissorsGame {
         return gameResult
     }
     
-    private func judgeWinOrLoseAtMCB(MCB: (MukChiBba, MukChiBba), to turn: Turn) {
-        switch MCB {
+    private func judgeWinOrLoseAtMukChiBba(MukChiBba: (MukChiBba, MukChiBba), to turn: Turn) {
+        switch MukChiBba {
         case let (userMCB, computerMCB) where userMCB == computerMCB:
             print("\(turn.rawValue)의 승리!")
         case (.chi, .bba), (.bba, .muk), (.muk, .chi) :
             print("사용자의 턴입니다.")
-            playMCB(turn: .user)
+            playMukChiBba(turn: .user)
         default:
             print("컴퓨터의 턴입니다.")
-            playMCB(turn: .computer)
+            playMukChiBba(turn: .computer)
         }
     }
     
@@ -120,10 +120,10 @@ struct RockPaperScissorsGame {
         switch result {
         case .win:
             print(GameComment.gameWin.rawValue)
-            playMCB(turn: .user)
+            playMukChiBba(turn: .user)
         case .lose:
             print(GameComment.gameLose.rawValue)
-            playMCB(turn: .computer)
+            playMukChiBba(turn: .computer)
         case .draw:
             print(GameComment.gameDraw.rawValue)
             play()

--- a/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
@@ -101,15 +101,15 @@ struct MukChiBbaGame {
         return gameResult
     }
     
-    private func judgeWinOrLoseAtMukChiBba(MCB: (MukChiBba, MukChiBba), to turn: Turn) {
+    func judgeWinOrLoseAtMukChiBba(MCB: (MukChiBba, MukChiBba), to turn: Turn) {
         switch MCB {
         case let (userMCB, computerMCB) where userMCB == computerMCB:
             print("\(turn.rawValue)의 승리!")
         case (.chi, .bba), (.bba, .muk), (.muk, .chi):
-            print("사용자의 턴입니다.")
+            print(GameComment.userTurn.rawValue)
             playMukChiBba(turn: .user)
         default:
-            print("컴퓨터의 턴입니다.")
+            print(GameComment.computerTurn.rawValue)
             playMukChiBba(turn: .computer)
         }
     }

--- a/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
+++ b/RockPaperScissors/RockPaperScissors/MukChiBbaGame.swift
@@ -14,11 +14,11 @@ struct MukChiBbaGame {
             return
         }
         
-        guard let tupleRockPaperScissors =  convertRockPaperScissors(inputNumber: userNumber) else {
+        guard let tupleRockPaperScissors =  convertRockPaperScissors(to: userNumber) else {
             return play()
         }
         
-        let userGameResult = judgeWinOrLoseAtRockPaperScissors(RockPaperScissors:
+        let userGameResult = judgeWinOrLoseAtRockPaperScissors(RPS:
         tupleRockPaperScissors)
         
         showResult(userGameResult)
@@ -37,11 +37,11 @@ struct MukChiBbaGame {
             return
         }
         
-        guard let tupleMukChiBba = convertMukChiBba(inputNumber: userNumber) else {
+        guard let tupleMukChiBba = convertMukChiBba(to: userNumber) else {
             return playMukChiBba(turn: .computer)
         }
         
-        judgeWinOrLoseAtMukChiBba(MukChiBba: tupleMukChiBba, to: turn)
+        judgeWinOrLoseAtMukChiBba(MCB: tupleMukChiBba, to: turn)
     }
     
     private func showRockPaperScissorsMenu() {
@@ -68,7 +68,7 @@ struct MukChiBbaGame {
         return true
     }
     
-    private func convertRockPaperScissors(inputNumber: Int)
+    private func convertRockPaperScissors(to inputNumber: Int)
     -> (RockPaperScissors, RockPaperScissors)? {
         guard let numberToRPS: RockPaperScissors = .init(rawValue: inputNumber),
               let computerRPS: RockPaperScissors = .init(rawValue: Int.random(in: 1...3)) else {
@@ -78,7 +78,7 @@ struct MukChiBbaGame {
         return (numberToRPS, computerRPS)
     }
     
-    private func convertMukChiBba(inputNumber: Int) -> (MukChiBba, MukChiBba)? {
+    private func convertMukChiBba(to inputNumber: Int) -> (MukChiBba, MukChiBba)? {
         guard let userNumberMCB: MukChiBba = .init(rawValue: inputNumber),
               let computerMCB: MukChiBba = .init(rawValue: Int.random(in: 1...3)) else {
             print(GameComment.retry.rawValue)
@@ -87,15 +87,14 @@ struct MukChiBbaGame {
         return (userNumberMCB, computerMCB)
     }
     
-    private func judgeWinOrLoseAtRockPaperScissors(
-        RockPaperScissors: (RockPaperScissors, RockPaperScissors)
-    ) -> GameResult {
+    private func judgeWinOrLoseAtRockPaperScissors(RPS: (RockPaperScissors, RockPaperScissors))
+    -> GameResult {
         let gameResult: GameResult
         
-        switch RockPaperScissors {
+        switch RPS {
         case let (userRPS, computerRPS) where userRPS == computerRPS:
             gameResult = .draw
-        case (.scissors, .paper), (.paper, .rock), (.rock, .scissors) :
+        case (.scissors, .paper), (.paper, .rock), (.rock, .scissors):
             gameResult = .win
         default:
             gameResult = .lose
@@ -103,11 +102,11 @@ struct MukChiBbaGame {
         return gameResult
     }
     
-    private func judgeWinOrLoseAtMukChiBba(MukChiBba: (MukChiBba, MukChiBba), to turn: Turn) {
-        switch MukChiBba {
+    private func judgeWinOrLoseAtMukChiBba(MCB: (MukChiBba, MukChiBba), to turn: Turn) {
+        switch MCB {
         case let (userMCB, computerMCB) where userMCB == computerMCB:
             print("\(turn.rawValue)의 승리!")
-        case (.chi, .bba), (.bba, .muk), (.muk, .chi) :
+        case (.chi, .bba), (.bba, .muk), (.muk, .chi):
             print("사용자의 턴입니다.")
             playMukChiBba(turn: .user)
         default:

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissors.swift
@@ -4,4 +4,10 @@ enum RockPaperScissors: Int {
     case scissors = 1
     case rock = 2
     case paper = 3
+    
+    static func random() -> RockPaperScissors {
+        let rps: [Self] = [.scissors, .rock, .paper]
+        let randomNumber = Int.random(in: 0...2)
+        return rps[randomNumber]
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
@@ -58,6 +58,15 @@ struct RockPaperScissorsGame {
         return (numberToRPS, computerRPS)
     }
     
+    private func convertMCB(inputNumber: Int) -> (MukChiBba, MukChiBba)? {
+        guard let userNumberMCB: MukChiBba = .init(rawValue: inputNumber),
+              let computerMCB: MukChiBba = .init(rawValue: Int.random(in: 1...3)) else {
+            print(GameComment.retry.rawValue)
+            return nil
+        }
+        return (userNumberMCB, computerMCB)
+    }
+    
     private func judgeWinOrLoseAtRPS(RPS: (RockPaperScissors, RockPaperScissors)) -> GameResult {
         let gameResult: GameResult
         

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
@@ -23,6 +23,28 @@ struct RockPaperScissorsGame {
         showResult(userGameResult)
     }
     
+    func playMCB(turn: Turn) {
+        showMCBMenu(turn: turn)
+        
+        guard let userNumber = inputUserNumber() else {
+            print(GameComment.retry.rawValue)
+            playMCB(turn: .computer)
+            return
+        }
+        
+        if checkEndGame(userNumber) {
+            print(GameComment.gameOver.rawValue)
+            return
+        }
+        
+        guard let compareMCB = convertMCB(inputNumber: userNumber) else {
+            playMCB(turn: .computer)
+            return
+        }
+        
+        judgeWinOrLoseAtMCB(MCB: (userMCB, computerMCB), to: turn)
+    }
+    
     private func showMenu() {
         print(GameComment.gameRPSMenu.rawValue, terminator: "")
     }
@@ -87,8 +109,10 @@ struct RockPaperScissorsGame {
             print("\(turn.rawValue)의 승리!")
         case (.chi, .bba), (.bba, .muk), (.muk, .chi) :
             print("사용자의 턴입니다.")
+            playMCB(turn: .user)
         default:
             print("컴퓨터의 턴입니다.")
+            playMCB(turn: .computer)
         }
     }
     
@@ -96,8 +120,10 @@ struct RockPaperScissorsGame {
         switch result {
         case .win:
             print(GameComment.gameWin.rawValue)
+            playMCB(turn: .user)
         case .lose:
             print(GameComment.gameLose.rawValue)
+            playMCB(turn: .computer)
         case .draw:
             print(GameComment.gameDraw.rawValue)
             play()

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
@@ -24,7 +24,11 @@ struct RockPaperScissorsGame {
     }
     
     private func showMenu() {
-        print(GameComment.gameMenu.rawValue, terminator: "")
+        print(GameComment.gameRPSMenu.rawValue, terminator: "")
+    }
+    
+    private func showMCBMenu(turn: Turn) {
+        print("[\(turn.rawValue) 턴] \(GameComment.gameMCBMenu.rawValue)", terminator: "")
     }
     
     private func inputUserNumber() -> Int? {

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
@@ -68,6 +68,17 @@ struct RockPaperScissorsGame {
         return gameResult
     }
     
+    private func judgeWinOrLoseAtMCB(MCB: (MukChiBba, MukChiBba), to turn: Turn) {
+        switch MCB {
+        case let (userMCB, computerMCB) where userMCB == computerMCB:
+            print("\(turn.rawValue)의 승리!")
+        case (.chi, .bba), (.bba, .muk), (.muk, .chi) :
+            print("사용자의 턴입니다.")
+        default:
+            print("컴퓨터의 턴입니다.")
+        }
+    }
+    
     private func showResult(_ result: GameResult) {
         switch result {
         case .win:

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsGame.swift
@@ -2,16 +2,23 @@
 
 struct RockPaperScissorsGame {
     func play() {
-        let userNumber = validateUserNumber()
+        guard let userNumber = inputUserNumber() else {
+            print(GameComment.retry.rawValue)
+            play()
+            return
+        }
         
         if checkEndGame(userNumber) {
             print(GameComment.gameOver.rawValue)
             return
         }
         
-        let userRPS = convertRPS(inputNumber: userNumber)
-        let computerRPS = convertRPS(inputNumber: Int.random(in: 1...3))
-        let userGameResult = judgeWinOrLose(userRPS, computerRPS)
+        guard let compareRPS =  convertRPS(inputNumber: userNumber) else {
+            play()
+            return
+        }
+        
+        let userGameResult = judgeWinOrLoseAtRPS(RPS: compareRPS)
         
         showResult(userGameResult)
     }
@@ -31,14 +38,6 @@ struct RockPaperScissorsGame {
         return inputUserNumberToInt
     }
     
-    private func validateUserNumber() -> Int {
-        guard let userNumber = inputUserNumber() else {
-            print(GameComment.retry.rawValue)
-            return validateUserNumber()
-        }
-        return userNumber
-    }
-    
     private func checkEndGame(_ userNumber: Int) -> Bool {
         if userNumber != 0 {
             return false
@@ -46,43 +45,25 @@ struct RockPaperScissorsGame {
         return true
     }
     
-    private func convertRPS(inputNumber: Int) -> RockPaperScissors {
-        guard let numberToRPS: RockPaperScissors = .init(rawValue: inputNumber) else {
+    private func convertRPS(inputNumber: Int) -> (RockPaperScissors, RockPaperScissors)? {
+        guard let numberToRPS: RockPaperScissors = .init(rawValue: inputNumber),
+              let computerRPS: RockPaperScissors = .init(rawValue: Int.random(in: 1...3)) else {
             print(GameComment.retry.rawValue)
-            return convertRPS(inputNumber: validateUserNumber())
+            return nil
         }
-        return numberToRPS
+        return (numberToRPS, computerRPS)
     }
     
-    private func judgeWinOrLose(
-        _ userRPS: RockPaperScissors,
-        _ computerRPS: RockPaperScissors)
-    -> GameResult {
-        var gameResult: GameResult = .draw
+    private func judgeWinOrLoseAtRPS(RPS: (RockPaperScissors, RockPaperScissors)) -> GameResult {
+        let gameResult: GameResult
         
-        if userRPS == computerRPS {
-            return gameResult
-        }
-        
-        switch userRPS {
-        case .scissors:
-            if computerRPS == .paper {
-                gameResult = .win
-            } else if computerRPS == .rock {
-                gameResult = .lose
-            }
-        case .rock:
-            if computerRPS == .scissors {
-                gameResult = .win
-            } else if computerRPS == .paper {
-                gameResult = .lose
-            }
-        case .paper:
-            if computerRPS == .rock {
-                gameResult = .win
-            } else if computerRPS == .scissors {
-                gameResult = .lose
-            }
+        switch RPS {
+        case let (userRPS, computerRPS) where userRPS == computerRPS:
+            gameResult = .draw
+        case (.scissors, .paper), (.paper, .rock), (.rock, .scissors) :
+            gameResult = .win
+        default:
+            gameResult = .lose
         }
         return gameResult
     }

--- a/RockPaperScissors/RockPaperScissors/Turn.swift
+++ b/RockPaperScissors/RockPaperScissors/Turn.swift
@@ -1,0 +1,6 @@
+//  Created by 감자 and som on 2022/08/22.
+
+enum Turn: String {
+    case user = "사용자"
+    case computer = "컴퓨터"
+}

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -1,4 +1,4 @@
 //  Created by 감자 and som on 2022/08/22.
 
-let game = RockPaperScissorsGame()
+let game = MukChiBbaGame()
 game.play()


### PR DESCRIPTION
안녕하세요, @apwierk2451 ~!
저희 Step2 구현이 끝나서 PR 보냅니다😄

# 고민했던 부분

<img width="310" alt="스크린샷 2022-08-25 오전 10 18 34" src="https://user-images.githubusercontent.com/94514250/186648019-fa50f637-e6cf-43d8-9745-20b915a00798.png">

처음에 묵찌빠를 구현했을 때, 잘못된 숫자를 입력하면 "잘못된 입력입니다. 다시 시도해주세요." 문구만 출력될 뿐, 묵찌빠 메뉴는 출력되지 않았습니다.

- 이전의 코드
```Swift
private func convertRPS(inputNumber: Int) -> RockPaperScissors {
        guard let numberToRPS: RockPaperScissors = .init(rawValue: inputNumber) else {
            print(GameComment.retry.rawValue)
            return convertRPS(validateUserNumber())
        }
        return numberToRPS
    }
```

원인은 여기서 "잘못된 입력입니다. 다시 시도해주세요." 문구를 리턴하고 다시 재귀를 돌기 때문이었습니다. 
그래서 validateUserNumber() 메서드를 삭제하고 해당 기능을 play() 메서드에 구현했습니다.
그리고 여기서 재귀가 돌지 않도록 튜플 옵셔널 값을 반환하게 하고 해당 튜플 옵셔널 값을 judgeWinOrLose() 메서드를 활용하여 switch 구문으로 옵셔널 바인딩을 했습니다. 

- 이후의 코드
```Swift
private func convertMukChiBba(inputNumber: Int) -> (MukChiBba, MukChiBba)? {
        guard let userNumberMCB: MukChiBba = .init(rawValue: inputNumber),
              let computerMCB: MukChiBba = .init(rawValue: Int.random(in: 1...3)) else {
            print(GameComment.retry.rawValue)
            return nil
        }
        return (userNumberMCB, computerMCB)
    }

private func judgeWinOrLoseAtRPS(RPS: (RockPaperScissors, RockPaperScissors)) -> GameResult {
        
        let gameResult: GameResult
        
        switch RPS {
        case let (userRPS, computerRPS) where userRPS == computerRPS:
            gameResult = .draw
        case (.scissors, .paper), (.paper, .rock), (.rock, .scissors) :
            gameResult = .win
        default:
            gameResult = .lose
        }
        return gameResult
    }
```

# 조언을 구하고 싶은 부분
- RockPaperScissors의 약자인 RPS를 그동안 변수명이나 메서드명으로 사용하고 있었는데, 지난번 리뷰에서도 본프가 상대방이 알아들을 수 없는 약자는 사용하지 않는 게 좋다고 하셔서 그 부분 저희도 수용하여 이번에는 약자의 사용을 줄였습니다. 하지만 그대로 사용하자니 코드의 길이가 길어져서 고민이 되는데요, 이 부분은 어떻게 해결하는 게 좋을까요?